### PR TITLE
Add a DateSerializer

### DIFF
--- a/src/main/java/me/prettyprint/cassandra/serializers/DateSerializer.java
+++ b/src/main/java/me/prettyprint/cassandra/serializers/DateSerializer.java
@@ -1,0 +1,37 @@
+package me.prettyprint.cassandra.serializers;
+
+import java.util.Date;
+
+/**
+ * Converts bytes to Date and vice versa, by first converting the Date to or
+ * from a long which represents the specified number of milliseconds since
+ * the standard base time known as "the Unix epoch", that is
+ * January 1, 1970, 00:00:00 UTC.
+ *
+ * @author Jim Ancona
+ * @see java.util.Date
+ */
+public final class DateSerializer extends AbstractSerializer<Date> {
+  private static final LongSerializer LONG_SERIALIZER = LongSerializer.get();
+  private static final DateSerializer instance = new DateSerializer();
+
+  public static DateSerializer get() {
+    return instance;
+  }
+
+  @Override
+  public byte[] toBytes(Date obj) {
+    if (obj == null) {
+      return null;
+    }
+    return LONG_SERIALIZER.toBytes(obj.getTime());
+  }
+
+  @Override
+  public Date fromBytes(byte[] bytes) {
+    if (bytes == null) {
+      return null;
+    }
+    return new Date(LONG_SERIALIZER.fromBytes(bytes));
+  }
+}

--- a/src/main/java/me/prettyprint/cassandra/serializers/SerializerTypeInferer.java
+++ b/src/main/java/me/prettyprint/cassandra/serializers/SerializerTypeInferer.java
@@ -1,5 +1,6 @@
 package me.prettyprint.cassandra.serializers;
 
+import java.util.Date;
 import java.util.UUID;
 
 import me.prettyprint.hector.api.Serializer;
@@ -28,6 +29,8 @@ public class SerializerTypeInferer {
       serializer = BooleanSerializer.get();
     } else if (value instanceof byte[]) {
       serializer = BytesSerializer.get();
+    } else if (value instanceof Date) {
+      serializer = DateSerializer.get();
     } else {
       serializer = ObjectSerializer.get();
     }
@@ -36,7 +39,7 @@ public class SerializerTypeInferer {
     return serializer;
   }
 
-  @SuppressWarnings("rawtypes")
+  @SuppressWarnings({ "rawtypes", "unchecked" })
   public static <T> Serializer<T> getSerializer(Class<?> valueClass) {
     Serializer serializer = null;
     if (valueClass.equals(UUID.class)) {

--- a/src/test/java/me/prettyprint/cassandra/serializers/DateSerializerTest.java
+++ b/src/test/java/me/prettyprint/cassandra/serializers/DateSerializerTest.java
@@ -1,0 +1,29 @@
+package me.prettyprint.cassandra.serializers;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Date;
+
+import org.junit.Test;
+
+/**
+ * @author  Jim Ancona
+ */
+public class DateSerializerTest {
+
+  @Test
+  public void testConversions() {
+    test(new Date());
+    test(new Date(0l));
+    test(new Date(1l));
+    test(new Date(-1l));
+    test(new Date(Long.MAX_VALUE));
+    test(new Date(Long.MIN_VALUE));
+    test(null);
+  }
+
+  private void test(Date date) {
+    DateSerializer ext = DateSerializer.get();
+    assertEquals(date, ext.fromBytes(ext.toBytes(date)));
+  }
+}


### PR DESCRIPTION
Hi,

I thought it would be useful to add a DateSerializer. This one serializes a java.util.Date using LongSerializer where the long value is the number of milliseconds since January 1, 1970, 00:00:00 UTC, which is also the "Unix Epoch", so the serialized values are potentially useful for non-Java clients as well.

Jim
