### PR TITLE
Improve Clock Resolution

### DIFF
--- a/src/main/java/me/prettyprint/cassandra/service/ClockResolution.java
+++ b/src/main/java/me/prettyprint/cassandra/service/ClockResolution.java
@@ -10,12 +10,22 @@ package me.prettyprint.cassandra.service;
  */
 public enum ClockResolution {
   SECONDS, MILLISECONDS, MICROSECONDS;
-  
+  /**
+   * The last time value issued. Used to try to prevent duplicates.
+   */
+  private static long lastTime = Long.MIN_VALUE;
+
   public long createClock() {
     long current = System.currentTimeMillis();
     switch(this) {
     case MICROSECONDS:
-      return current * 1000;
+      long us = current * 1000;
+      if (us > lastTime) {
+        lastTime = us;
+      } else {
+        us = ++lastTime;
+      }
+      return us;
     case MILLISECONDS:
       return current;
     case SECONDS:


### PR DESCRIPTION
On my previous pull request, Rantav wrote:

> You're probably aware that there's not JVM support for currentTimeMicro so a few alternatives exist:
> 1. It's been suggested on the mailing list to keep a static counter that simply increases with every call to createClock. May be good enough in some cases
> 2. Create a combination of both createTimeMilli and System.nanoTime() which has the potential of values with better semantics, but you'd have to think of a way to synch both clocks so they make sense together.

I used the approach in number 1 to avoid issuing duplicate clocks from the same JVM by storing the last time issued in a static. I elected not to synchronize, so there is probably a race that can still lead to duplicate values. Anyone think it would be better to synchronize?
