### PR TITLE
TApplicationException translation issue

### DIFF
--- a/src/main/java/me/prettyprint/cassandra/service/ExceptionsTranslatorImpl.java
+++ b/src/main/java/me/prettyprint/cassandra/service/ExceptionsTranslatorImpl.java
@@ -11,6 +11,7 @@ import me.prettyprint.hector.api.exceptions.HectorTransportException;
 import me.prettyprint.hector.api.exceptions.PoolExhaustedException;
 import me.prettyprint.hector.api.exceptions.PoolIllegalStateException;
 
+import org.apache.thrift.TApplicationException;
 import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TProtocolException;
 import org.apache.thrift.transport.TTransportException;
@@ -21,6 +22,8 @@ public final class ExceptionsTranslatorImpl implements ExceptionsTranslator {
   public HectorException translate(Throwable original) {
     if (original instanceof HectorException) {
       return (HectorException) original;
+    } else if (original instanceof TApplicationException) {
+      return new HInvalidRequestException(original);
     } else if (original instanceof TException || original instanceof TTransportException) {
       return new HectorTransportException(original);
     } else if (original instanceof org.apache.cassandra.thrift.TimedOutException) {


### PR DESCRIPTION
Cassandra appears to throw a TApplicationException when it encounters an internal error, as in this example:

Caused by: org.apache.thrift.TApplicationException: Internal error processing batch_mutate
    at org.apache.thrift.TApplicationException.read(TApplicationException.java:108)
    at org.apache.cassandra.thrift.Cassandra$Client.recv_batch_mutate(Cassandra.java:908)
    at org.apache.cassandra.thrift.Cassandra$Client.batch_mutate(Cassandra.java:890)
    at me.prettyprint.cassandra.service.KeyspaceServiceImpl$1.execute(KeyspaceServiceImpl.java:93)
...

Right now ExceptionTranslatorImpl treats TApplicationException as its parent TException, and throws a HectorTransportException, which causes the retry logic in HConnectionManager to kick in. This is bad because retrying just causes the same error to recur, so you end up with the entire cluster marked down. I don't see any reason to retry these, so this patch changes it to throw a HInvalidRequestException instead. 
