### PR TITLE
java.lang.NoSuchMethodError cannot be cast to java.lang.RuntimeException

### DIFF
--- a/core/src/main/java/me/prettyprint/cassandra/service/JmxMonitor.java
+++ b/core/src/main/java/me/prettyprint/cassandra/service/JmxMonitor.java
@@ -101,7 +101,7 @@ public class JmxMonitor {
       } catch( IllegalAccessException e ) {
         log.error( "Could not invoke method DOMConfigurator.configure(URL)", e );
       } catch( InvocationTargetException e ) {
-        throw (RuntimeException) e.getCause();
+        throw new RuntimeException(e.getCause());
       }
     }
   }


### PR DESCRIPTION
InvocationTargetException is not an instance of RuntimeException and thus cannot be cast to a RuntimeException. Instead, RuntimeException can just encapsulate the InvocationTargetException.
