### PR TITLE
HectorTemplate API addition

### DIFF
--- a/core/src/main/java/me/prettyprint/cassandra/service/spring/HectorTemplate.java
+++ b/core/src/main/java/me/prettyprint/cassandra/service/spring/HectorTemplate.java
@@ -117,6 +117,11 @@ public interface HectorTemplate {
    * Creates a column with the clock of now.
    */
   <N, V> HColumn<N, V> createColumn(N name, V value);
+  
+  /**
+   * Creates a column with the specified <code>name/value</code> and <code>clock</code>.
+   */
+  <N, V> HColumn<N, V> createColumn(N name, V value, long clock);
 
   /**
    * Creates a clock of now with the default clock resolution (micorosec) as defined in

--- a/core/src/main/java/me/prettyprint/cassandra/service/spring/HectorTemplateImpl.java
+++ b/core/src/main/java/me/prettyprint/cassandra/service/spring/HectorTemplateImpl.java
@@ -216,6 +216,11 @@ public class HectorTemplateImpl implements HectorTemplate {
   public <N, V> HColumn<N, V> createColumn(N name, V value) {
     return new HColumnImpl<N, V>(name, value, createClock());
   }
+  
+  @Override
+  public <N, V> HColumn<N, V> createColumn(N name, V value, long clock) {
+    return new HColumnImpl<N, V>(name, value, clock);
+  }
 
   @Override
   public long createClock() {


### PR DESCRIPTION
Per our conversation on the template, I just overloaded createColumn to specify a name/value/clock.
fyi- We could probably remove the "spring" package, since there is nothing spring about these classes,
and we don't do any spring imports.  But the template pattern is definitely more attractive to me!
