### PR TITLE
Mutable collections

### DIFF
--- a/core/src/main/java/me/prettyprint/cassandra/model/ColumnSliceImpl.java
+++ b/core/src/main/java/me/prettyprint/cassandra/model/ColumnSliceImpl.java
@@ -28,7 +28,7 @@ public final class ColumnSliceImpl<N,V> implements ColumnSlice<N, V> {
       columnsMap.put(column.getName(), column);
       list.add(column);
     }
-    columnsList = Collections.unmodifiableList(list);
+    columnsList = list;
   }
 
   /**

--- a/core/src/main/java/me/prettyprint/cassandra/model/HSuperColumnImpl.java
+++ b/core/src/main/java/me/prettyprint/cassandra/model/HSuperColumnImpl.java
@@ -30,7 +30,7 @@ import org.apache.cassandra.thrift.SuperColumn;
 public final class HSuperColumnImpl<SN,N,V> implements HSuperColumn<SN, N, V> {
 
   private SN superName;
-  private List<? extends HColumn<N,V>> columns;
+  private List<HColumn<N,V>> columns;
   private long clock;
   private final Serializer<SN> superNameSerializer;
   private final Serializer<N> nameSerializer;
@@ -109,7 +109,7 @@ public final class HSuperColumnImpl<SN,N,V> implements HSuperColumn<SN, N, V> {
    */
   @Override
   public List<HColumn<N,V>> getColumns() {
-    return Collections.unmodifiableList(columns);
+    return columns;
   }
 
   @Override

--- a/core/src/main/java/me/prettyprint/cassandra/model/OrderedRowsImpl.java
+++ b/core/src/main/java/me/prettyprint/cassandra/model/OrderedRowsImpl.java
@@ -1,11 +1,6 @@
 package me.prettyprint.cassandra.model;
 
-import java.util.ArrayDeque;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import me.prettyprint.hector.api.Serializer;
 import me.prettyprint.hector.api.beans.OrderedRows;
@@ -23,12 +18,12 @@ import org.apache.cassandra.thrift.Column;
  */
 public final class OrderedRowsImpl<K,N,V> extends RowsImpl<K,N,V> implements OrderedRows<K, N, V> {
 
-  private final ArrayDeque<Row<K,N,V>> rowsList;
+  private final List<Row<K,N,V>> rowsList;
 
   public OrderedRowsImpl(LinkedHashMap<K, List<Column>> thriftRet, Serializer<N> nameSerializer,
       Serializer<V> valueSerializer) {
     super(thriftRet, nameSerializer, valueSerializer);
-    rowsList = new ArrayDeque<Row<K,N,V>>(rows.values());    
+    rowsList = new ArrayList<Row<K,N,V>>(rows.values());
   }
 
   /**
@@ -37,7 +32,7 @@ public final class OrderedRowsImpl<K,N,V> extends RowsImpl<K,N,V> implements Ord
    */
   @Override
   public List<Row<K,N,V>> getList() {
-    return Collections.unmodifiableList(new ArrayList<Row<K, N, V>>(rowsList));
+    return rowsList;
   }
 
   /**
@@ -46,6 +41,6 @@ public final class OrderedRowsImpl<K,N,V> extends RowsImpl<K,N,V> implements Ord
    */
   @Override
   public Row<K, N, V> peekLast() {
-    return rowsList != null && rowsList.size() > 0 ? rowsList.peekLast() : null;
+    return rowsList != null && rowsList.size() > 0 ? rowsList.get(rowsList.size()-1) : null;
   }
 }

--- a/core/src/main/java/me/prettyprint/cassandra/model/OrderedSuperRowsImpl.java
+++ b/core/src/main/java/me/prettyprint/cassandra/model/OrderedSuperRowsImpl.java
@@ -39,6 +39,6 @@ public final class OrderedSuperRowsImpl<K,SN,N,V> extends SuperRowsImpl<K,SN,N,V
    */
   @Override
   public List<SuperRow<K,SN,N,V>> getList() {
-    return Collections.unmodifiableList(rowsList);
+    return rowsList;
   }
 }

--- a/core/src/main/java/me/prettyprint/cassandra/model/SuperSliceImpl.java
+++ b/core/src/main/java/me/prettyprint/cassandra/model/SuperSliceImpl.java
@@ -44,7 +44,7 @@ public final class SuperSliceImpl<SN,N,V> implements SuperSlice<SN, N, V> {
    */
   @Override
   public List<HSuperColumn<SN,N,V>> getSuperColumns() {
-    return Collections.unmodifiableList(columnsList);
+    return columnsList;
 
   }
 

--- a/core/src/test/java/me/prettyprint/hector/api/ApiV2SystemTest.java
+++ b/core/src/test/java/me/prettyprint/hector/api/ApiV2SystemTest.java
@@ -213,6 +213,15 @@ public class ApiV2SystemTest extends BaseEmbededServerSetupTest {
     assertEquals("name2", c2.getName());
     assertEquals("value2", c2.getValue());
 
+     {
+        Iterator<HColumn<String, String>> it = sc.getColumns().iterator();
+        while(it.hasNext()){
+           it.next();
+           it.remove();
+        }
+        assertEquals("The list of columns should be mutable", 0, sc.getColumns().size());
+     }
+
     // remove value
     m = createMutator(ko, se);
     m.subDelete("testSuperInsertGetRemove", cf, "testSuperInsertGetRemove",
@@ -709,7 +718,15 @@ public class ApiV2SystemTest extends BaseEmbededServerSetupTest {
         }
       }
     }
+     {
+        Iterator<SuperRow<String, String, String, String>> it = rows.getList().iterator();
+        while(it.hasNext()){
+           it.next();
+           it.remove();
+        }
+        assertEquals("The list of super rows should be mutable", 0, rows.getList().size());
 
+     }
     // Delete values
     deleteColumns(cleanup);
   }


### PR DESCRIPTION
(from https://groups.google.com/d/topic/hector-dev/KDh3jSVhaAU/discussion)

All tests pass.

(...)
I noticed that this not always possible with Hector. For instance OrderedSuperRows.getList returns an unmodifiable list, so does HSuperColumnImpl#getColumns.

I don't see why the user will be forbidden to alter the returned collections. 
I found only 5 (not 4) valid occurences, so the change seems small.

```
    HSuperColumnImpl.java  
        (112: 23) return Collections.unmodifiableList(columns);
    OrderedRowsImpl.java  
        (40: 23) return Collections.unmodifiableList(new ArrayList<Row<K, N, V>>(rowsList));
    OrderedSuperRowsImpl.java  
        (38: 23) return Collections.unmodifiableList(rowsList);
    SuperSliceImpl.java  
        (47: 23) return Collections.unmodifiableList(columnsList);
    ColumnSliceImpl
```

Would you guys agree to drop this constraint?

ps: as of today the immutability constraint is not always applied. For instance SuperRowsImpl#iterator is mutable.
