### PR TITLE
Npe in ByteBufferSerializer

### DIFF
--- a/core/src/main/java/me/prettyprint/cassandra/serializers/ByteBufferSerializer.java
+++ b/core/src/main/java/me/prettyprint/cassandra/serializers/ByteBufferSerializer.java
@@ -14,8 +14,7 @@ import me.prettyprint.hector.api.Serializer;
  * @author Ran Tavory
  * 
  */
-public final class ByteBufferSerializer extends AbstractSerializer<ByteBuffer>
-    implements Serializer<ByteBuffer> {
+public final class ByteBufferSerializer extends AbstractSerializer<ByteBuffer>{
 
   private static ByteBufferSerializer instance = new ByteBufferSerializer();
 


### PR DESCRIPTION
ByteBufferSerializer does not check for null values. Some NPE happens, in particular during SuperColumnQuery. See [ThriftSuperColumnQuery.java, line 49](https://github.com/rantav/hector/blob/master/core/src/main/java/me/prettyprint/cassandra/model/thrift/ThriftSuperColumnQuery.java#L49)
