### PR TITLE
inconsistency in StringSerializer

### DIFF
--- a/core/src/main/java/me/prettyprint/cassandra/serializers/StringSerializer.java
+++ b/core/src/main/java/me/prettyprint/cassandra/serializers/StringSerializer.java
@@ -15,7 +15,7 @@ public final class StringSerializer extends AbstractSerializer<String> {
 
   private static final String UTF_8 = "UTF-8";
   private static final StringSerializer instance = new StringSerializer();
-  private static final Charset charset = Charset.defaultCharset();
+  private static final Charset charset =Charset.forName(UTF_8);
 
   public static StringSerializer get() {
     return instance;
@@ -26,11 +26,7 @@ public final class StringSerializer extends AbstractSerializer<String> {
     if (obj == null) {
       return null;
     }
-    try {
-      return ByteBuffer.wrap(obj.getBytes(charset.name()));
-    } catch (UnsupportedEncodingException e) {
-      throw new RuntimeException(e);
-    }
+    return ByteBuffer.wrap(obj.getBytes(charset));
   }
 
   @Override


### PR DESCRIPTION
I noticed small glitches in StringSerializer:
- The javadoc in StringSerializer states that UTF8 is used, but the code uses the default charset. 
- using the default charset seems risky since it can change from one environment to another
- using getBytes(String charsetName) instead of getBytes(Charset charset) means the charset is always looked up

This fix sets UTF8 as the charset.
