### PR TITLE
Requesting a less verbose Hector

### DIFF
--- a/core/src/main/resources/hectorLog4j.xml
+++ b/core/src/main/resources/hectorLog4j.xml
@@ -46,7 +46,7 @@
       upstream loggers.
     -->
     <logger name="me.prettyprint.cassandra.hector.TimingLogger" additivity="false">
-        <level value="info"/>
+        <level value="TRACE"/>
         <appender-ref ref="hector_CoalescingStatistics"/>
     </logger>
 


### PR DESCRIPTION
This has been discussed before - new users of Hector have to take additional steps to silence Hector's TimingLogger. All debates about logging best-practices aside, I believe that Hector's default logging configuration should not seek to emit performance info. It should be the less common scenario that requires the  extra logging configuration effort.
