### PR TITLE
SCF setKeys/setColumnNames overloading with Collection type

### DIFF
--- a/core/src/main/java/me/prettyprint/cassandra/model/thrift/ThriftMultigetSubSliceQuery.java
+++ b/core/src/main/java/me/prettyprint/cassandra/model/thrift/ThriftMultigetSubSliceQuery.java
@@ -45,6 +45,12 @@ public final class ThriftMultigetSubSliceQuery<K, SN, N, V> extends AbstractSlic
     return this;
   }
 
+  @Override
+  public MultigetSubSliceQuery<K, SN, N, V> setKeys(Collection<K> keys) {
+    this.keys = keys;
+    return this;
+  }
+
   /**
    * Set the supercolumn to run the slice query on
    */
@@ -100,4 +106,11 @@ public final class ThriftMultigetSubSliceQuery<K, SN, N, V> extends AbstractSlic
   public MultigetSubSliceQuery<K, SN, N, V> setColumnNames(N... columnNames) {
     return (MultigetSubSliceQuery<K, SN, N, V>) super.setColumnNames(columnNames);
   }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public MultigetSubSliceQuery<K, SN, N, V> setColumnNames(Collection<N> columnNames) {
+    return (MultigetSubSliceQuery<K, SN, N, V>) super.setColumnNames(columnNames);
+  }
+
 }

--- a/core/src/main/java/me/prettyprint/cassandra/model/thrift/ThriftMultigetSuperSliceQuery.java
+++ b/core/src/main/java/me/prettyprint/cassandra/model/thrift/ThriftMultigetSuperSliceQuery.java
@@ -50,6 +50,12 @@ public final class ThriftMultigetSuperSliceQuery<K, SN, N, V> extends
   }
 
   @Override
+  public MultigetSuperSliceQuery<K, SN, N, V> setKeys(Collection<K> keys) {
+    this.keys = keys;
+    return this;
+  }
+
+  @Override
   public QueryResult<SuperRows<K, SN, N, V>> execute() {
     return new QueryResultImpl<SuperRows<K, SN, N, V>>(
         keyspace.doExecute(new KeyspaceOperationCallback<SuperRows<K, SN, N, V>>() {
@@ -80,6 +86,12 @@ public final class ThriftMultigetSuperSliceQuery<K, SN, N, V> extends
   @SuppressWarnings("unchecked")
   @Override
   public MultigetSuperSliceQuery<K, SN, N, V> setColumnNames(SN... columnNames) {
+    return (MultigetSuperSliceQuery<K, SN, N, V>) super.setColumnNames(columnNames);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public MultigetSuperSliceQuery<K, SN, N, V> setColumnNames(Collection<SN> columnNames) {
     return (MultigetSuperSliceQuery<K, SN, N, V>) super.setColumnNames(columnNames);
   }
 

--- a/core/src/main/java/me/prettyprint/hector/api/query/MultigetSubSliceQuery.java
+++ b/core/src/main/java/me/prettyprint/hector/api/query/MultigetSubSliceQuery.java
@@ -13,6 +13,8 @@ public interface MultigetSubSliceQuery<K, SN, N, V> extends Query<Rows<K, N, V>>
 
   MultigetSubSliceQuery<K, SN, N, V> setKeys(K... keys);
 
+  MultigetSubSliceQuery<K, SN, N, V> setKeys(Collection<K> keys);
+
   /**
    * Set the supercolumn to run the slice query on
    */
@@ -29,5 +31,7 @@ public interface MultigetSubSliceQuery<K, SN, N, V> extends Query<Rows<K, N, V>>
    * @param columns a list of column names
    */
   MultigetSubSliceQuery<K, SN, N, V> setColumnNames(N... columnNames);
+
+  MultigetSubSliceQuery<K, SN, N, V> setColumnNames(Collection<N> columnNames);
 
 }

--- a/core/src/main/java/me/prettyprint/hector/api/query/MultigetSuperSliceQuery.java
+++ b/core/src/main/java/me/prettyprint/hector/api/query/MultigetSuperSliceQuery.java
@@ -13,6 +13,8 @@ public interface MultigetSuperSliceQuery<K, SN, N, V> extends Query<SuperRows<K,
 
   MultigetSuperSliceQuery<K, SN, N, V> setKeys(K... keys);
 
+  MultigetSuperSliceQuery<K, SN, N, V> setKeys(Collection<K> keys);
+
   MultigetSuperSliceQuery<K, SN, N, V> setColumnFamily(String cf);
 
   MultigetSuperSliceQuery<K, SN, N, V> setRange(SN start, SN finish, boolean reversed, int count);
@@ -24,5 +26,7 @@ public interface MultigetSuperSliceQuery<K, SN, N, V> extends Query<SuperRows<K,
    * @param columns a list of column names
    */
   MultigetSuperSliceQuery<K, SN, N, V> setColumnNames(SN... columnNames);
+
+  MultigetSuperSliceQuery<K, SN, N, V> setColumnNames(Collection<SN> columnNames);
 
 }


### PR DESCRIPTION
I initiated pull request to the master branch by mistake. This should have been 0.7.0.

MultigetSliceQuery has setKeys method accepts Iterable argument as well as variable arguments.

This patch adds similar functionality to setKeys/setColumnNames in MultigetSuperSliceQuery and MultigetSubSliceQuery.
