### PR TITLE
NodeAutoDiscoverService does not behave correctly when authentication is enabled

### DIFF
--- a/core/src/main/java/me/prettyprint/cassandra/connection/NodeAutoDiscoverService.java
+++ b/core/src/main/java/me/prettyprint/cassandra/connection/NodeAutoDiscoverService.java
@@ -7,8 +7,14 @@ import java.util.concurrent.TimeUnit;
 
 import me.prettyprint.cassandra.service.CassandraHost;
 import me.prettyprint.cassandra.service.CassandraHostConfigurator;
+import me.prettyprint.cassandra.service.ThriftCluster;
+import me.prettyprint.hector.api.Cluster;
 import me.prettyprint.hector.api.Keyspace;
+import me.prettyprint.hector.api.ddl.KeyspaceDefinition;
+import me.prettyprint.hector.api.factory.HFactory;
 
+import org.apache.cassandra.thrift.AuthenticationRequest;
+import org.apache.cassandra.thrift.Cassandra;
 import org.apache.cassandra.thrift.KsDef;
 import org.apache.cassandra.thrift.TokenRange;
 import org.slf4j.Logger;
@@ -77,14 +83,17 @@ public class NodeAutoDiscoverService extends BackgroundCassandraHostService {
     Set<CassandraHost> existingHosts = connectionManager.getHosts();
     Set<CassandraHost> foundHosts = new HashSet<CassandraHost>();
 
-    HThriftClient thriftClient = null;
     log.info("using existing hosts {}", existingHosts);
     try {
-      thriftClient = connectionManager.borrowClient();
+      
+      String clusterName = connectionManager.getClusterName();
+      
+      //this could be suspect, but we need this 
+      ThriftCluster cluster = (ThriftCluster) HFactory.getCluster(clusterName);
 
-      for (KsDef keyspace : thriftClient.getCassandra().describe_keyspaces()) {
-        if (!keyspace.getName().equals(Keyspace.KEYSPACE_SYSTEM)) {
-          List<TokenRange> tokenRanges = thriftClient.getCassandra().describe_ring(keyspace.getName());
+      for(KeyspaceDefinition keyspaceDefinition: cluster.describeKeyspaces()) {    	  
+        if (!keyspaceDefinition.getName().equals(Keyspace.KEYSPACE_SYSTEM)) {
+          List<TokenRange> tokenRanges = cluster.describeRing(keyspaceDefinition.getName());
           for (TokenRange tokenRange : tokenRanges) {
             for (String host : tokenRange.getEndpoints()) {
               CassandraHost foundHost = new CassandraHost(host,cassandraHostConfigurator.getPort());
@@ -99,9 +108,10 @@ public class NodeAutoDiscoverService extends BackgroundCassandraHostService {
       }
     } catch (Exception e) {
       log.error("Discovery Service failed attempt to connect CassandraHost", e);
-    } finally {
-      connectionManager.releaseClient(thriftClient);
     }
+//    } finally {
+//      connectionManager.releaseClient(thriftClient);
+//    }
     return foundHosts;
   }
 

--- a/core/src/main/java/me/prettyprint/hector/api/Cluster.java
+++ b/core/src/main/java/me/prettyprint/hector/api/Cluster.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.cassandra.thrift.TokenRange;
+
 import me.prettyprint.cassandra.connection.HConnectionManager;
 import me.prettyprint.cassandra.service.CassandraHost;
 import me.prettyprint.hector.api.ddl.ColumnFamilyDefinition;
@@ -47,6 +49,8 @@ public interface Cluster {
   KeyspaceDefinition describeKeyspace(final String keyspace) throws HectorException;
 
   List<KeyspaceDefinition> describeKeyspaces() throws HectorException;
+  
+  List<TokenRange> describeRing(final String keyspace) throws HectorException;
 
   /**
    * Drops the Keyspace from the cluster. Equivalent of 'drop database' in SQL terms


### PR DESCRIPTION
This is an attempt to fix the following issue:
https://github.com/rantav/hector/issues/203

I made a quick change, but due to issues linking with an outside project I still need to test this.  Also, if there's a location for JUnit test that I can build out, let me know.  I wasn't sure how easy it would be to test an authenticated cassandra instance in junit test.  Maybe just a new test class that functionally tests NodeAutoDiscoverService.

Thoughts?  Maybe interface change at Cluster.java with a Hector specific class?

Let me know what you think.  I can tune it a bit.

Nick
