### PR TITLE
This fixes an incorrect deserialziation issue with composite times and reversed comparator mapping

### DIFF
--- a/core/src/main/java/me/prettyprint/cassandra/serializers/DynamicCompositeSerializer.java
+++ b/core/src/main/java/me/prettyprint/cassandra/serializers/DynamicCompositeSerializer.java
@@ -15,24 +15,30 @@ import me.prettyprint.hector.api.ddl.ComparatorType;
  * 
  */
 public class DynamicCompositeSerializer extends
-    AbstractSerializer<DynamicComposite> {
+		AbstractSerializer<DynamicComposite> {
 
-  @Override
-  public ByteBuffer toByteBuffer(DynamicComposite obj) {
+	private static final DynamicCompositeSerializer instance = new DynamicCompositeSerializer();
 
-    return obj.serialize();
-  }
+	public static DynamicCompositeSerializer get() {
+		return instance;
+	}
 
-  @Override
-  public DynamicComposite fromByteBuffer(ByteBuffer byteBuffer) {
+	@Override
+	public ByteBuffer toByteBuffer(DynamicComposite obj) {
 
-    return DynamicComposite.fromByteBuffer(byteBuffer);
+		return obj.serialize();
+	}
 
-  }
+	@Override
+	public DynamicComposite fromByteBuffer(ByteBuffer byteBuffer) {
 
-  @Override
-  public ComparatorType getComparatorType() {
-    return DYNAMICCOMPOSITETYPE;
-  }
+		return DynamicComposite.fromByteBuffer(byteBuffer);
+
+	}
+
+	@Override
+	public ComparatorType getComparatorType() {
+		return DYNAMICCOMPOSITETYPE;
+	}
 
 }

--- a/core/src/main/java/me/prettyprint/cassandra/serializers/TimeUUIDSerializer.java
+++ b/core/src/main/java/me/prettyprint/cassandra/serializers/TimeUUIDSerializer.java
@@ -1,0 +1,56 @@
+package me.prettyprint.cassandra.serializers;
+
+import static me.prettyprint.hector.api.ddl.ComparatorType.TIMEUUIDTYPE;
+
+import java.nio.ByteBuffer;
+import com.eaio.uuid.UUID;
+
+import me.prettyprint.hector.api.ddl.ComparatorType;
+
+/**
+ * A UUIDSerializer translates the byte[] to and from UUID types. for Time based UUIDS
+ * 
+ * @author Todd Nine
+ * 
+ */
+public final class TimeUUIDSerializer extends AbstractSerializer<UUID> {
+
+  private static final TimeUUIDSerializer instance = new TimeUUIDSerializer();
+
+  public static TimeUUIDSerializer get() {
+    return instance;
+  }
+
+  @Override
+  public ByteBuffer toByteBuffer(UUID uuid) {
+    if (uuid == null) {
+      return null;
+    }
+    long msb = uuid.getTime();
+    long lsb = uuid.getClockSeqAndNode();
+    byte[] buffer = new byte[16];
+
+    for (int i = 0; i < 8; i++) {
+      buffer[i] = (byte) (msb >>> 8 * (7 - i));
+    }
+    for (int i = 8; i < 16; i++) {
+      buffer[i] = (byte) (lsb >>> 8 * (7 - i));
+    }
+
+    return ByteBuffer.wrap(buffer);
+  }
+
+  @Override
+  public UUID fromByteBuffer(ByteBuffer bytes) {
+    if (bytes == null) {
+      return null;
+    }
+    return new UUID(bytes.getLong(), bytes.getLong());
+  }
+
+  @Override
+  public ComparatorType getComparatorType() {
+    return TIMEUUIDTYPE;
+  }
+
+}

--- a/core/src/main/java/me/prettyprint/hector/api/beans/AbstractComposite.java
+++ b/core/src/main/java/me/prettyprint/hector/api/beans/AbstractComposite.java
@@ -375,7 +375,7 @@ public abstract class AbstractComposite extends AbstractList<Object> implements
           byte a = (byte) (header & 0xFF);
           name = aliasToComparatorMapping.get(a);
           if (name == null) {
-            a = (byte) Character.toUpperCase((char) a);
+            a = (byte) Character.toLowerCase((char) a);
             name = aliasToComparatorMapping.get(a);
             if (name != null) {
               name += "(reversed=true)";

--- a/core/src/test/java/me/prettyprint/hector/api/beans/DynamicCompositeTest.java
+++ b/core/src/test/java/me/prettyprint/hector/api/beans/DynamicCompositeTest.java
@@ -1,0 +1,82 @@
+package me.prettyprint.hector.api.beans;
+
+import static org.junit.Assert.*;
+
+import java.nio.ByteBuffer;
+import java.util.UUID;
+
+import me.prettyprint.cassandra.serializers.AsciiSerializer;
+import me.prettyprint.cassandra.serializers.BytesArraySerializer;
+import me.prettyprint.cassandra.serializers.DynamicCompositeSerializer;
+import me.prettyprint.cassandra.serializers.IntegerSerializer;
+import me.prettyprint.cassandra.serializers.LongSerializer;
+import me.prettyprint.cassandra.serializers.StringSerializer;
+import me.prettyprint.cassandra.serializers.TimeUUIDSerializer;
+import me.prettyprint.cassandra.serializers.UUIDSerializer;
+import me.prettyprint.hector.api.beans.AbstractComposite.ComponentEquality;
+
+import org.apache.cassandra.db.marshal.AsciiType;
+import org.apache.cassandra.db.marshal.LexicalUUIDType;
+import org.junit.Test;
+
+public class DynamicCompositeTest {
+
+	@Test
+	public void allTypesSerialize() {
+		DynamicComposite composite = new DynamicComposite();
+		
+		UUID lexUUID = UUID.randomUUID();
+		com.eaio.uuid.UUID timeUUID = new com.eaio.uuid.UUID();
+		
+	
+		//add all forward comparators
+		composite.addComponent(0, "AsciiText", AsciiSerializer.get(), "AsciiType", ComponentEquality.EQUAL);
+		composite.addComponent(1, new byte[]{0, 1, 2, 3}, BytesArraySerializer.get(), "BytesType", ComponentEquality.EQUAL);
+		composite.addComponent(2, -1, IntegerSerializer.get(), "IntegerType", ComponentEquality.EQUAL);
+		composite.addComponent(3,  lexUUID, UUIDSerializer.get(), "LexicalUUIDType", ComponentEquality.EQUAL);
+		composite.addComponent(4, -1l, LongSerializer.get(), "LongType", ComponentEquality.EQUAL);
+		composite.addComponent(5, timeUUID, TimeUUIDSerializer.get(), "TimeUUIDType", ComponentEquality.EQUAL);
+		composite.addComponent(6, "UTF8Text", StringSerializer.get(), "UTF8Type", ComponentEquality.EQUAL);
+		composite.addComponent(7,  lexUUID, UUIDSerializer.get(), "UUIDType", ComponentEquality.EQUAL);
+		
+		//add all reverse comparators
+		composite.addComponent(8, "AsciiText", AsciiSerializer.get(), "AsciiType(reversed=true)", ComponentEquality.EQUAL);
+		composite.addComponent(9, new byte[]{0, 1, 2, 3}, BytesArraySerializer.get(), "BytesType(reversed=true)", ComponentEquality.EQUAL);
+		composite.addComponent(10, -1, IntegerSerializer.get(), "IntegerType(reversed=true)", ComponentEquality.EQUAL);
+		composite.addComponent(11,  lexUUID, UUIDSerializer.get(), "LexicalUUIDType(reversed=true)", ComponentEquality.EQUAL);
+		composite.addComponent(12, -1l, LongSerializer.get(), "LongType(reversed=true)", ComponentEquality.EQUAL);
+		composite.addComponent(13, timeUUID, TimeUUIDSerializer.get(), "TimeUUIDType(reversed=true)", ComponentEquality.EQUAL);
+		composite.addComponent(14, "UTF8Text", StringSerializer.get(), "UTF8Type(reversed=true)", ComponentEquality.EQUAL);
+		composite.addComponent(15,  lexUUID, UUIDSerializer.get(), "UUIDType(reversed=true)", ComponentEquality.EQUAL);
+		
+		//serialize to the native bytes value
+		
+		ByteBuffer buffer = DynamicCompositeSerializer.get().toByteBuffer(composite);
+		
+	
+		//now deserialize and ensure the values are the same
+		DynamicComposite parsed = DynamicCompositeSerializer.get().fromByteBuffer(buffer);
+		
+		assertEquals("AsciiText", parsed.get(0, AsciiSerializer.get()));
+		assertArrayEquals(new byte[]{0, 1, 2, 3}, parsed.get(1, BytesArraySerializer.get()));
+		assertEquals(Integer.valueOf(-1), parsed.get(2, IntegerSerializer.get()));
+		assertEquals(lexUUID, parsed.get(3, UUIDSerializer.get()));
+		assertEquals(Long.valueOf(-1l), parsed.get(4, LongSerializer.get()));
+		assertEquals(timeUUID, parsed.get(5, TimeUUIDSerializer.get()));
+		assertEquals("UTF8Text", parsed.get(6, StringSerializer.get()));
+		assertEquals(lexUUID, parsed.get(7, UUIDSerializer.get()));
+		
+		//now test all the reversed values
+		assertEquals("AsciiText", parsed.get(8, AsciiSerializer.get()));
+		assertArrayEquals(new byte[]{0, 1, 2, 3}, parsed.get(9, BytesArraySerializer.get()));
+		assertEquals(Integer.valueOf(-1), parsed.get(10, IntegerSerializer.get()));
+		assertEquals(lexUUID, parsed.get(11, UUIDSerializer.get()));
+		assertEquals(Long.valueOf(-1l), parsed.get(12, LongSerializer.get()));
+		assertEquals(timeUUID, parsed.get(13, TimeUUIDSerializer.get()));
+		assertEquals("UTF8Text", parsed.get(14, StringSerializer.get()));
+		assertEquals(lexUUID, parsed.get(15, UUIDSerializer.get()));
+		
+
+	}
+
+}


### PR DESCRIPTION
Creates test that validates the I/O of all default type mappings as well
as reverse mappings.  

Fixes issue with incorrect upper/lower casing on
mapping types in deserialize.

Adds singleton to TimeUUIDSerializer
