### PR TITLE
Dynamic composite in memory compareTo implemenation incorrect

### DIFF
--- a/core/src/test/java/me/prettyprint/hector/api/beans/DynamicCompositeTest.java
+++ b/core/src/test/java/me/prettyprint/hector/api/beans/DynamicCompositeTest.java
@@ -79,4 +79,27 @@ public class DynamicCompositeTest {
 
 	}
 
+	
+	/**
+	 * Tests that when compared in memory, values are correctly sorted using the correct comparator
+	 */
+	@Test
+	public void correctComparatorsUsed(){
+		
+		long minLong = 1311163200000l;
+		long maxLong = 1313928000000l;
+		
+		DynamicComposite min = new DynamicComposite();
+		min.addComponent(minLong, LongSerializer.get());
+		
+		
+		DynamicComposite max = new DynamicComposite();
+		max.addComponent(maxLong, LongSerializer.get());
+		
+		
+		int compare = max.compareTo(min);
+		
+		assertTrue(compare > 0);
+		
+	}
 }


### PR DESCRIPTION
Hi guys,
  While developing the hector-jpa plugin, I've come across this bug in hector-core.  When 2 dynamic composite are compared, they are compared in memory using the ByteBuffer comparator.  This is incorrect, as each component in the the DynamicComposite affects the comparison order when stored in Casandra.  I've attached a patch which demonstrates the bug when using large Long values.  I'm not sure the best approach to fix this, since this will require the comparators in the cassandra runtime to also be in the client's classpath.
