### PR TITLE
Types for Dates, Booleans, Floats and Doubles

### DIFF
--- a/core/src/main/java/me/prettyprint/cassandra/serializers/BooleanSerializer.java
+++ b/core/src/main/java/me/prettyprint/cassandra/serializers/BooleanSerializer.java
@@ -1,5 +1,7 @@
 package me.prettyprint.cassandra.serializers;
 
+import me.prettyprint.hector.api.ddl.ComparatorType;
+
 import java.nio.ByteBuffer;
 
 /**
@@ -37,4 +39,8 @@ public final class BooleanSerializer extends AbstractSerializer<Boolean> {
     return b == (byte) 1;
   }
 
+    @Override
+    public ComparatorType getComparatorType() {
+        return ComparatorType.BOOLEANTYPE;
+    }
 }

--- a/core/src/main/java/me/prettyprint/cassandra/serializers/BooleanSerializer.java
+++ b/core/src/main/java/me/prettyprint/cassandra/serializers/BooleanSerializer.java
@@ -39,8 +39,8 @@ public final class BooleanSerializer extends AbstractSerializer<Boolean> {
     return b == (byte) 1;
   }
 
-    @Override
-    public ComparatorType getComparatorType() {
-        return ComparatorType.BOOLEANTYPE;
-    }
+  @Override
+  public ComparatorType getComparatorType() {
+      return ComparatorType.BOOLEANTYPE;
+  }
 }

--- a/core/src/main/java/me/prettyprint/cassandra/serializers/DateSerializer.java
+++ b/core/src/main/java/me/prettyprint/cassandra/serializers/DateSerializer.java
@@ -38,8 +38,8 @@ public final class DateSerializer extends AbstractSerializer<Date> {
     return new Date(LONG_SERIALIZER.fromByteBuffer(bytes));
   }
 
-    @Override
-    public ComparatorType getComparatorType() {
-        return ComparatorType.DATETYPE;
-    }
+  @Override
+  public ComparatorType getComparatorType() {
+      return ComparatorType.DATETYPE;
+  }
 }

--- a/core/src/main/java/me/prettyprint/cassandra/serializers/DateSerializer.java
+++ b/core/src/main/java/me/prettyprint/cassandra/serializers/DateSerializer.java
@@ -1,5 +1,7 @@
 package me.prettyprint.cassandra.serializers;
 
+import me.prettyprint.hector.api.ddl.ComparatorType;
+
 import java.nio.ByteBuffer;
 import java.util.Date;
 
@@ -35,4 +37,9 @@ public final class DateSerializer extends AbstractSerializer<Date> {
     }
     return new Date(LONG_SERIALIZER.fromByteBuffer(bytes));
   }
+
+    @Override
+    public ComparatorType getComparatorType() {
+        return ComparatorType.DATETYPE;
+    }
 }

--- a/core/src/main/java/me/prettyprint/cassandra/serializers/DoubleSerializer.java
+++ b/core/src/main/java/me/prettyprint/cassandra/serializers/DoubleSerializer.java
@@ -4,6 +4,7 @@ import java.nio.ByteBuffer;
 
 import me.prettyprint.cassandra.serializers.AbstractSerializer;
 import me.prettyprint.cassandra.serializers.LongSerializer;
+import me.prettyprint.hector.api.ddl.ComparatorType;
 
 /**
  * Uses LongSerializer via translating Doubles to and from raw long bytes form.
@@ -26,6 +27,11 @@ public class DoubleSerializer extends AbstractSerializer<Double> {
   @Override
   public Double fromByteBuffer(ByteBuffer bytes) {
     return Double.longBitsToDouble (LongSerializer.get().fromByteBuffer(bytes));
+  }
+
+  @Override
+  public ComparatorType getComparatorType() {
+    return ComparatorType.DOUBLETYPE;
   }
 
 }

--- a/core/src/main/java/me/prettyprint/cassandra/serializers/DoubleSerializer.java
+++ b/core/src/main/java/me/prettyprint/cassandra/serializers/DoubleSerializer.java
@@ -35,4 +35,3 @@ public class DoubleSerializer extends AbstractSerializer<Double> {
   }
 
 }
-

--- a/core/src/main/java/me/prettyprint/cassandra/serializers/FloatSerializer.java
+++ b/core/src/main/java/me/prettyprint/cassandra/serializers/FloatSerializer.java
@@ -1,5 +1,7 @@
 package me.prettyprint.cassandra.serializers;
 
+import me.prettyprint.hector.api.ddl.ComparatorType;
+
 import java.nio.ByteBuffer;
 
 /**
@@ -23,6 +25,11 @@ public class FloatSerializer extends AbstractSerializer<Float> {
   @Override
   public Float fromByteBuffer(ByteBuffer bytes) {
     return Float.intBitsToFloat(IntegerSerializer.get().fromByteBuffer(bytes));
+  }
+
+  @Override
+  public ComparatorType getComparatorType() {
+    return ComparatorType.FLOATTYPE;
   }
 
 }

--- a/core/src/main/java/me/prettyprint/cassandra/serializers/SerializerTypeInferer.java
+++ b/core/src/main/java/me/prettyprint/cassandra/serializers/SerializerTypeInferer.java
@@ -39,6 +39,10 @@ public class SerializerTypeInferer {
       serializer = ByteBufferSerializer.get();
     } else if (value instanceof Date) {
       serializer = DateSerializer.get();
+    } else if (value instanceof Float) {
+      serializer = FloatSerializer.get();
+    } else if (value instanceof Double) {
+      serializer = DoubleSerializer.get();
     } else {
       serializer = ObjectSerializer.get();
     }
@@ -67,6 +71,10 @@ public class SerializerTypeInferer {
       serializer = ByteBufferSerializer.get();
     } else if (valueClass.equals(Date.class)) {
       serializer = DateSerializer.get();
+    } else if (valueClass.equals(Float.class) || valueClass.equals(float.class)) {
+      serializer = FloatSerializer.get();
+    } else if (valueClass.equals(Double.class) || valueClass.equals(double.class)) {
+      serializer = DoubleSerializer.get();
     } else {
       serializer = ObjectSerializer.get();
     }

--- a/core/src/main/java/me/prettyprint/hector/api/beans/AbstractComposite.java
+++ b/core/src/main/java/me/prettyprint/hector/api/beans/AbstractComposite.java
@@ -1,5 +1,18 @@
 package me.prettyprint.hector.api.beans;
 
+import static me.prettyprint.hector.api.ddl.ComparatorType.ASCIITYPE;
+import static me.prettyprint.hector.api.ddl.ComparatorType.BOOLEANTYPE;
+import static me.prettyprint.hector.api.ddl.ComparatorType.BYTESTYPE;
+import static me.prettyprint.hector.api.ddl.ComparatorType.DATETYPE;
+import static me.prettyprint.hector.api.ddl.ComparatorType.DOUBLETYPE;
+import static me.prettyprint.hector.api.ddl.ComparatorType.FLOATTYPE;
+import static me.prettyprint.hector.api.ddl.ComparatorType.INTEGERTYPE;
+import static me.prettyprint.hector.api.ddl.ComparatorType.LEXICALUUIDTYPE;
+import static me.prettyprint.hector.api.ddl.ComparatorType.LONGTYPE;
+import static me.prettyprint.hector.api.ddl.ComparatorType.TIMEUUIDTYPE;
+import static me.prettyprint.hector.api.ddl.ComparatorType.UTF8TYPE;
+import static me.prettyprint.hector.api.ddl.ComparatorType.UUIDTYPE;
+
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.nio.charset.CharacterCodingException;
@@ -28,8 +41,6 @@ import com.google.common.base.Charsets;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.ImmutableBiMap;
 import com.google.common.collect.ImmutableClassToInstanceMap;
-
-import static me.prettyprint.hector.api.ddl.ComparatorType.*;
 
 /**
  * Parent class of Composite and DynamicComposite. Acts as a list of objects
@@ -117,7 +128,7 @@ public abstract class AbstractComposite extends AbstractList<Object> implements
       .put((byte) 't', TIMEUUIDTYPE.getTypeName())
       .put((byte) 'u', UUIDTYPE.getTypeName())
       .put((byte) 'x', LEXICALUUIDTYPE.getTypeName())
-            .build();
+          .build();
 
   BiMap<Class<? extends Serializer>, String> serializerToComparatorMapping = DEFAULT_SERIALIZER_TO_COMPARATOR_MAPPING;
 

--- a/core/src/main/java/me/prettyprint/hector/api/beans/AbstractComposite.java
+++ b/core/src/main/java/me/prettyprint/hector/api/beans/AbstractComposite.java
@@ -1,14 +1,5 @@
 package me.prettyprint.hector.api.beans;
 
-import static me.prettyprint.hector.api.ddl.ComparatorType.ASCIITYPE;
-import static me.prettyprint.hector.api.ddl.ComparatorType.BYTESTYPE;
-import static me.prettyprint.hector.api.ddl.ComparatorType.INTEGERTYPE;
-import static me.prettyprint.hector.api.ddl.ComparatorType.LEXICALUUIDTYPE;
-import static me.prettyprint.hector.api.ddl.ComparatorType.LONGTYPE;
-import static me.prettyprint.hector.api.ddl.ComparatorType.TIMEUUIDTYPE;
-import static me.prettyprint.hector.api.ddl.ComparatorType.UTF8TYPE;
-import static me.prettyprint.hector.api.ddl.ComparatorType.UUIDTYPE;
-
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.nio.charset.CharacterCodingException;
@@ -37,6 +28,8 @@ import com.google.common.base.Charsets;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.ImmutableBiMap;
 import com.google.common.collect.ImmutableClassToInstanceMap;
+
+import static me.prettyprint.hector.api.ddl.ComparatorType.*;
 
 /**
  * Parent class of Composite and DynamicComposite. Acts as a list of objects
@@ -96,15 +89,35 @@ public abstract class AbstractComposite extends AbstractList<Object> implements
       .put(StringSerializer.class, StringSerializer.get())
       .put(UUIDSerializer.class, UUIDSerializer.get()).build();
 
+  /*
+    New Extended set of aliases supported since cassandra 0.8.1
+      a=>AsciiType
+      b=>BytesType
+      d=>DateType
+      e=>BooleanType
+      f=>FloatType
+      i=>IntegerType
+      l=>LongType
+      o=>DoubleType
+      s=>UTF8Type
+      t=>TimeUUIDType
+      u=>UUIDType
+      x=>LexicalUUIDType
+   */
   public static final BiMap<Byte, String> DEFAULT_ALIAS_TO_COMPARATOR_MAPPING = new ImmutableBiMap.Builder<Byte, String>()
       .put((byte) 'a', ASCIITYPE.getTypeName())
       .put((byte) 'b', BYTESTYPE.getTypeName())
+      .put((byte) 'd', DATETYPE.getTypeName())
+      .put((byte) 'e', BOOLEANTYPE.getTypeName())
+      .put((byte) 'f', FLOATTYPE.getTypeName())
       .put((byte) 'i', INTEGERTYPE.getTypeName())
-      .put((byte) 'x', LEXICALUUIDTYPE.getTypeName())
       .put((byte) 'l', LONGTYPE.getTypeName())
-      .put((byte) 't', TIMEUUIDTYPE.getTypeName())
+      .put((byte) 'o', DOUBLETYPE.getTypeName())
       .put((byte) 's', UTF8TYPE.getTypeName())
-      .put((byte) 'u', UUIDTYPE.getTypeName()).build();
+      .put((byte) 't', TIMEUUIDTYPE.getTypeName())
+      .put((byte) 'u', UUIDTYPE.getTypeName())
+      .put((byte) 'x', LEXICALUUIDTYPE.getTypeName())
+            .build();
 
   BiMap<Class<? extends Serializer>, String> serializerToComparatorMapping = DEFAULT_SERIALIZER_TO_COMPARATOR_MAPPING;
 
@@ -305,7 +318,7 @@ public abstract class AbstractComposite extends AbstractList<Object> implements
     if (comparator != null) {
       return comparator;
     }
-    return BYTESTYPE.getTypeName();
+    return s.getComparatorType().getTypeName();
   }
 
   private Serializer<?> serializerForComparator(String c) {

--- a/core/src/main/java/me/prettyprint/hector/api/beans/DynamicComposite.java
+++ b/core/src/main/java/me/prettyprint/hector/api/beans/DynamicComposite.java
@@ -5,7 +5,40 @@ import java.util.List;
 
 public class DynamicComposite extends AbstractComposite {
 
-  public final static String DEFAULT_DYNAMIC_COMPOSITE_ALIASES = "(a=>AsciiType,b=>BytesType,i=>IntegerType,x=>LexicalUUIDType,l=>LongType,t=>TimeUUIDType,s=>UTF8Type,u=>UUIDType,A=>AsciiType(reversed=true),B=>BytesType(reversed=true),I=>IntegerType(reversed=true),X=>LexicalUUIDType(reversed=true),L=>LongType(reversed=true),T=>TimeUUIDType(reversed=true),S=>UTF8Type(reversed=true),U=>UUIDType(reversed=true))";
+  public final static String DEFAULT_DYNAMIC_COMPOSITE_ALIASES =
+          "(a=>AsciiType,b=>BytesType,i=>IntegerType,x=>LexicalUUIDType,l=>LongType,t=>TimeUUIDType,s=>UTF8Type,u=>UUIDType,A=>AsciiType(reversed=true),B=>BytesType(reversed=true),I=>IntegerType(reversed=true),X=>LexicalUUIDType(reversed=true),L=>LongType(reversed=true),T=>TimeUUIDType(reversed=true),S=>UTF8Type(reversed=true),U=>UUIDType(reversed=true))";
+
+    /** Adds in new native types added in Cassandra 0.8.1
+     *       DateType, BooleanType, FloatType, DoubleType
+     */
+  public final static String EXTENDED_DYNAMIC_COMPOSITE_ALIASES =
+          "(a=>AsciiType," +
+          "b=>BytesType," +
+          "d=>DateType," +
+          "e=>BooleanType," +
+          "f=>FloatType," +
+          "i=>IntegerType," +
+          "l=>LongType," +
+          "o=>DoubleType," +
+          "s=>UTF8Type," +
+          "t=>TimeUUIDType," +
+          "u=>UUIDType," +
+          "x=>LexicalUUIDType," +
+
+          "A=>AsciiType(reversed=true)," +
+          "B=>BytesType(reversed=true)," +
+          "D=>DateType," +
+          "E=>BooleanType," +
+          "F=>FloatType," +
+          "I=>IntegerType(reversed=true)," +
+          "L=>LongType(reversed=true)," +
+          "O=>DoubleType(reversed=true)," +
+          "S=>UTF8Type(reversed=true)," +
+          "T=>TimeUUIDType(reversed=true)," +
+          "U=>UUIDType(reversed=true)," +
+          "X=>LexicalUUIDType(reversed=true))";
+
+
 
   public DynamicComposite() {
     super(true);

--- a/core/src/main/java/me/prettyprint/hector/api/beans/DynamicComposite.java
+++ b/core/src/main/java/me/prettyprint/hector/api/beans/DynamicComposite.java
@@ -12,31 +12,31 @@ public class DynamicComposite extends AbstractComposite {
      *       DateType, BooleanType, FloatType, DoubleType
      */
   public final static String EXTENDED_DYNAMIC_COMPOSITE_ALIASES =
-          "(a=>AsciiType," +
-          "b=>BytesType," +
-          "d=>DateType," +
-          "e=>BooleanType," +
-          "f=>FloatType," +
-          "i=>IntegerType," +
-          "l=>LongType," +
-          "o=>DoubleType," +
-          "s=>UTF8Type," +
-          "t=>TimeUUIDType," +
-          "u=>UUIDType," +
-          "x=>LexicalUUIDType," +
+      "(a=>AsciiType," +
+      "b=>BytesType," +
+      "d=>DateType," +
+      "e=>BooleanType," +
+      "f=>FloatType," +
+      "i=>IntegerType," +
+      "l=>LongType," +
+      "o=>DoubleType," +
+      "s=>UTF8Type," +
+      "t=>TimeUUIDType," +
+      "u=>UUIDType," +
+      "x=>LexicalUUIDType," +
 
-          "A=>AsciiType(reversed=true)," +
-          "B=>BytesType(reversed=true)," +
-          "D=>DateType," +
-          "E=>BooleanType," +
-          "F=>FloatType," +
-          "I=>IntegerType(reversed=true)," +
-          "L=>LongType(reversed=true)," +
-          "O=>DoubleType(reversed=true)," +
-          "S=>UTF8Type(reversed=true)," +
-          "T=>TimeUUIDType(reversed=true)," +
-          "U=>UUIDType(reversed=true)," +
-          "X=>LexicalUUIDType(reversed=true))";
+      "A=>AsciiType(reversed=true)," +
+      "B=>BytesType(reversed=true)," +
+      "D=>DateType," +
+      "E=>BooleanType," +
+      "F=>FloatType," +
+      "I=>IntegerType(reversed=true)," +
+      "L=>LongType(reversed=true)," +
+      "O=>DoubleType(reversed=true)," +
+      "S=>UTF8Type(reversed=true)," +
+      "T=>TimeUUIDType(reversed=true)," +
+      "U=>UUIDType(reversed=true)," +
+      "X=>LexicalUUIDType(reversed=true))";
 
 
 

--- a/core/src/main/java/me/prettyprint/hector/api/ddl/ComparatorType.java
+++ b/core/src/main/java/me/prettyprint/hector/api/ddl/ComparatorType.java
@@ -30,9 +30,23 @@ public class ComparatorType {
   public static ComparatorType COUNTERTYPE = new ComparatorType(
       "org.apache.cassandra.db.marshal.CounterColumnType");
 
+  // New types added in cassandra 0.8.1
+  //    DateType, BooleanType, FloatType, DoubleType
+  public static ComparatorType DATETYPE = new ComparatorType(
+      "org.apache.cassandra.db.marshal.DateType");
+  public static ComparatorType BOOLEANTYPE = new ComparatorType(
+      "org.apache.cassandra.db.marshal.BooleanType");
+  public static ComparatorType FLOATTYPE = new ComparatorType(
+      "org.apache.cassandra.db.marshal.FloatType");
+  public static ComparatorType DOUBLETYPE = new ComparatorType(
+      "org.apache.cassandra.db.marshal.DoubleType");
+
+
+
   private static ComparatorType[] values = { ASCIITYPE, BYTESTYPE, INTEGERTYPE,
       LEXICALUUIDTYPE, LOCALBYPARTITIONERTYPE, LONGTYPE, TIMEUUIDTYPE,
-      UTF8TYPE, COMPOSITETYPE, DYNAMICCOMPOSITETYPE, UUIDTYPE, COUNTERTYPE };
+      UTF8TYPE, COMPOSITETYPE, DYNAMICCOMPOSITETYPE, UUIDTYPE, COUNTERTYPE,
+      DATETYPE, BOOLEANTYPE, FLOATTYPE, DOUBLETYPE };
 
   private final String className;
   private final String typeName;

--- a/core/src/test/java/me/prettyprint/hector/api/beans/DynamicCompositeTest.java
+++ b/core/src/test/java/me/prettyprint/hector/api/beans/DynamicCompositeTest.java
@@ -3,16 +3,10 @@ package me.prettyprint.hector.api.beans;
 import static org.junit.Assert.*;
 
 import java.nio.ByteBuffer;
+import java.util.Date;
 import java.util.UUID;
 
-import me.prettyprint.cassandra.serializers.AsciiSerializer;
-import me.prettyprint.cassandra.serializers.BytesArraySerializer;
-import me.prettyprint.cassandra.serializers.DynamicCompositeSerializer;
-import me.prettyprint.cassandra.serializers.IntegerSerializer;
-import me.prettyprint.cassandra.serializers.LongSerializer;
-import me.prettyprint.cassandra.serializers.StringSerializer;
-import me.prettyprint.cassandra.serializers.TimeUUIDSerializer;
-import me.prettyprint.cassandra.serializers.UUIDSerializer;
+import me.prettyprint.cassandra.serializers.*;
 import me.prettyprint.hector.api.beans.AbstractComposite.ComponentEquality;
 
 import org.apache.cassandra.db.marshal.AsciiType;
@@ -27,7 +21,8 @@ public class DynamicCompositeTest {
 		
 		UUID lexUUID = UUID.randomUUID();
 		com.eaio.uuid.UUID timeUUID = new com.eaio.uuid.UUID();
-		
+
+        Date date = new Date();
 	
 		//add all forward comparators
 		composite.addComponent(0, "AsciiText", AsciiSerializer.get(), "AsciiType", ComponentEquality.EQUAL);
@@ -38,17 +33,33 @@ public class DynamicCompositeTest {
 		composite.addComponent(5, timeUUID, TimeUUIDSerializer.get(), "TimeUUIDType", ComponentEquality.EQUAL);
 		composite.addComponent(6, "UTF8Text", StringSerializer.get(), "UTF8Type", ComponentEquality.EQUAL);
 		composite.addComponent(7,  lexUUID, UUIDSerializer.get(), "UUIDType", ComponentEquality.EQUAL);
-		
+
+        //  new types:    DateType, BooleanType, FloatType, DoubleType
+        composite.addComponent(8, date, DateSerializer.get(), "DateType", ComponentEquality.EQUAL);
+        composite.addComponent(9, true, BooleanSerializer.get(), "BooleanType", ComponentEquality.EQUAL);
+        composite.addComponent(10, 1.1f, FloatSerializer.get(), "FloatType", ComponentEquality.EQUAL);
+        composite.addComponent(11, 1.2d, DoubleSerializer.get(), "DoubleType", ComponentEquality.EQUAL);
+
+
+
 		//add all reverse comparators
-		composite.addComponent(8, "AsciiText", AsciiSerializer.get(), "AsciiType(reversed=true)", ComponentEquality.EQUAL);
-		composite.addComponent(9, new byte[]{0, 1, 2, 3}, BytesArraySerializer.get(), "BytesType(reversed=true)", ComponentEquality.EQUAL);
-		composite.addComponent(10, -1, IntegerSerializer.get(), "IntegerType(reversed=true)", ComponentEquality.EQUAL);
-		composite.addComponent(11,  lexUUID, UUIDSerializer.get(), "LexicalUUIDType(reversed=true)", ComponentEquality.EQUAL);
-		composite.addComponent(12, -1l, LongSerializer.get(), "LongType(reversed=true)", ComponentEquality.EQUAL);
-		composite.addComponent(13, timeUUID, TimeUUIDSerializer.get(), "TimeUUIDType(reversed=true)", ComponentEquality.EQUAL);
-		composite.addComponent(14, "UTF8Text", StringSerializer.get(), "UTF8Type(reversed=true)", ComponentEquality.EQUAL);
-		composite.addComponent(15,  lexUUID, UUIDSerializer.get(), "UUIDType(reversed=true)", ComponentEquality.EQUAL);
-		
+		composite.addComponent(12, "AsciiText", AsciiSerializer.get(), "AsciiType(reversed=true)", ComponentEquality.EQUAL);
+		composite.addComponent(13, new byte[]{0, 1, 2, 3}, BytesArraySerializer.get(), "BytesType(reversed=true)", ComponentEquality.EQUAL);
+		composite.addComponent(14, -1, IntegerSerializer.get(), "IntegerType(reversed=true)", ComponentEquality.EQUAL);
+		composite.addComponent(15,  lexUUID, UUIDSerializer.get(), "LexicalUUIDType(reversed=true)", ComponentEquality.EQUAL);
+		composite.addComponent(16, -1l, LongSerializer.get(), "LongType(reversed=true)", ComponentEquality.EQUAL);
+		composite.addComponent(17, timeUUID, TimeUUIDSerializer.get(), "TimeUUIDType(reversed=true)", ComponentEquality.EQUAL);
+		composite.addComponent(18, "UTF8Text", StringSerializer.get(), "UTF8Type(reversed=true)", ComponentEquality.EQUAL);
+		composite.addComponent(19,  lexUUID, UUIDSerializer.get(), "UUIDType(reversed=true)", ComponentEquality.EQUAL);
+
+        composite.addComponent(20, date, DateSerializer.get(), "DateType(reversed=true)", ComponentEquality.EQUAL);
+        composite.addComponent(21, true, BooleanSerializer.get(), "BooleanType(reversed=true)", ComponentEquality.EQUAL);
+        composite.addComponent(22, 1.1f, FloatSerializer.get(), "FloatType(reversed=true)", ComponentEquality.EQUAL);
+        composite.addComponent(23, 1.2d, DoubleSerializer.get(), "DoubleType(reversed=true)", ComponentEquality.EQUAL);
+
+
+
+
 		//serialize to the native bytes value
 		
 		ByteBuffer buffer = DynamicCompositeSerializer.get().toByteBuffer(composite);
@@ -65,16 +76,25 @@ public class DynamicCompositeTest {
 		assertEquals(timeUUID, parsed.get(5, TimeUUIDSerializer.get()));
 		assertEquals("UTF8Text", parsed.get(6, StringSerializer.get()));
 		assertEquals(lexUUID, parsed.get(7, UUIDSerializer.get()));
-		
+        assertEquals(date, parsed.get(8, DateSerializer.get()));
+        assertEquals(Boolean.TRUE, parsed.get(9, BooleanSerializer.get()));
+        assertEquals(new Float(1.1f), parsed.get(10, FloatSerializer.get()));
+        assertEquals(new Double(1.2d), parsed.get(11, DoubleSerializer.get()));
+
+
 		//now test all the reversed values
-		assertEquals("AsciiText", parsed.get(8, AsciiSerializer.get()));
-		assertArrayEquals(new byte[]{0, 1, 2, 3}, parsed.get(9, BytesArraySerializer.get()));
-		assertEquals(Integer.valueOf(-1), parsed.get(10, IntegerSerializer.get()));
-		assertEquals(lexUUID, parsed.get(11, UUIDSerializer.get()));
-		assertEquals(Long.valueOf(-1l), parsed.get(12, LongSerializer.get()));
-		assertEquals(timeUUID, parsed.get(13, TimeUUIDSerializer.get()));
-		assertEquals("UTF8Text", parsed.get(14, StringSerializer.get()));
+		assertEquals("AsciiText", parsed.get(12, AsciiSerializer.get()));
+		assertArrayEquals(new byte[]{0, 1, 2, 3}, parsed.get(13, BytesArraySerializer.get()));
+		assertEquals(Integer.valueOf(-1), parsed.get(14, IntegerSerializer.get()));
 		assertEquals(lexUUID, parsed.get(15, UUIDSerializer.get()));
+		assertEquals(Long.valueOf(-1l), parsed.get(16, LongSerializer.get()));
+		assertEquals(timeUUID, parsed.get(17, TimeUUIDSerializer.get()));
+		assertEquals("UTF8Text", parsed.get(18, StringSerializer.get()));
+		assertEquals(lexUUID, parsed.get(19, UUIDSerializer.get()));
+        assertEquals(date, parsed.get(20, DateSerializer.get()));
+        assertEquals(Boolean.TRUE, parsed.get(21, BooleanSerializer.get()));
+        assertEquals(new Float(1.1f), parsed.get(22, FloatSerializer.get()));
+        assertEquals(new Double(1.2d), parsed.get(23, DoubleSerializer.get()));
 		
 
 	}

--- a/core/src/test/java/me/prettyprint/hector/api/beans/DynamicCompositeTest.java
+++ b/core/src/test/java/me/prettyprint/hector/api/beans/DynamicCompositeTest.java
@@ -3,100 +3,109 @@ package me.prettyprint.hector.api.beans;
 import static org.junit.Assert.*;
 
 import java.nio.ByteBuffer;
-import java.util.Date;
 import java.util.UUID;
+import java.util.Date;
 
-import me.prettyprint.cassandra.serializers.*;
+import me.prettyprint.cassandra.serializers.AsciiSerializer;
+import me.prettyprint.cassandra.serializers.BooleanSerializer;
+import me.prettyprint.cassandra.serializers.BytesArraySerializer;
+import me.prettyprint.cassandra.serializers.DateSerializer;
+import me.prettyprint.cassandra.serializers.DoubleSerializer;
+import me.prettyprint.cassandra.serializers.DynamicCompositeSerializer;
+import me.prettyprint.cassandra.serializers.FloatSerializer;
+import me.prettyprint.cassandra.serializers.IntegerSerializer;
+import me.prettyprint.cassandra.serializers.LongSerializer;
+import me.prettyprint.cassandra.serializers.StringSerializer;
+import me.prettyprint.cassandra.serializers.TimeUUIDSerializer;
+import me.prettyprint.cassandra.serializers.UUIDSerializer;
 import me.prettyprint.hector.api.beans.AbstractComposite.ComponentEquality;
-
-import org.apache.cassandra.db.marshal.AsciiType;
-import org.apache.cassandra.db.marshal.LexicalUUIDType;
 import org.junit.Test;
+
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 
 public class DynamicCompositeTest {
 
-	@Test
-	public void allTypesSerialize() {
-		DynamicComposite composite = new DynamicComposite();
-		
-		UUID lexUUID = UUID.randomUUID();
-		com.eaio.uuid.UUID timeUUID = new com.eaio.uuid.UUID();
+  @Test
+  public void allTypesSerialize() {
+    DynamicComposite composite = new DynamicComposite();
 
-        Date date = new Date();
-	
-		//add all forward comparators
-		composite.addComponent(0, "AsciiText", AsciiSerializer.get(), "AsciiType", ComponentEquality.EQUAL);
-		composite.addComponent(1, new byte[]{0, 1, 2, 3}, BytesArraySerializer.get(), "BytesType", ComponentEquality.EQUAL);
-		composite.addComponent(2, -1, IntegerSerializer.get(), "IntegerType", ComponentEquality.EQUAL);
-		composite.addComponent(3,  lexUUID, UUIDSerializer.get(), "LexicalUUIDType", ComponentEquality.EQUAL);
-		composite.addComponent(4, -1l, LongSerializer.get(), "LongType", ComponentEquality.EQUAL);
-		composite.addComponent(5, timeUUID, TimeUUIDSerializer.get(), "TimeUUIDType", ComponentEquality.EQUAL);
-		composite.addComponent(6, "UTF8Text", StringSerializer.get(), "UTF8Type", ComponentEquality.EQUAL);
-		composite.addComponent(7,  lexUUID, UUIDSerializer.get(), "UUIDType", ComponentEquality.EQUAL);
+    UUID lexUUID = UUID.randomUUID();
+    com.eaio.uuid.UUID timeUUID = new com.eaio.uuid.UUID();
 
-        //  new types:    DateType, BooleanType, FloatType, DoubleType
-        composite.addComponent(8, date, DateSerializer.get(), "DateType", ComponentEquality.EQUAL);
-        composite.addComponent(9, true, BooleanSerializer.get(), "BooleanType", ComponentEquality.EQUAL);
-        composite.addComponent(10, 1.1f, FloatSerializer.get(), "FloatType", ComponentEquality.EQUAL);
-        composite.addComponent(11, 1.2d, DoubleSerializer.get(), "DoubleType", ComponentEquality.EQUAL);
+    Date date = new Date();
 
+    //add all forward comparators
+    composite.addComponent(0, "AsciiText", AsciiSerializer.get(), "AsciiType", ComponentEquality.EQUAL);
+    composite.addComponent(1, new byte[]{0, 1, 2, 3}, BytesArraySerializer.get(), "BytesType", ComponentEquality.EQUAL);
+    composite.addComponent(2, -1, IntegerSerializer.get(), "IntegerType", ComponentEquality.EQUAL);
+    composite.addComponent(3, lexUUID, UUIDSerializer.get(), "LexicalUUIDType", ComponentEquality.EQUAL);
+    composite.addComponent(4, -1l, LongSerializer.get(), "LongType", ComponentEquality.EQUAL);
+    composite.addComponent(5, timeUUID, TimeUUIDSerializer.get(), "TimeUUIDType", ComponentEquality.EQUAL);
+    composite.addComponent(6, "UTF8Text", StringSerializer.get(), "UTF8Type", ComponentEquality.EQUAL);
+    composite.addComponent(7, lexUUID, UUIDSerializer.get(), "UUIDType", ComponentEquality.EQUAL);
 
-
-		//add all reverse comparators
-		composite.addComponent(12, "AsciiText", AsciiSerializer.get(), "AsciiType(reversed=true)", ComponentEquality.EQUAL);
-		composite.addComponent(13, new byte[]{0, 1, 2, 3}, BytesArraySerializer.get(), "BytesType(reversed=true)", ComponentEquality.EQUAL);
-		composite.addComponent(14, -1, IntegerSerializer.get(), "IntegerType(reversed=true)", ComponentEquality.EQUAL);
-		composite.addComponent(15,  lexUUID, UUIDSerializer.get(), "LexicalUUIDType(reversed=true)", ComponentEquality.EQUAL);
-		composite.addComponent(16, -1l, LongSerializer.get(), "LongType(reversed=true)", ComponentEquality.EQUAL);
-		composite.addComponent(17, timeUUID, TimeUUIDSerializer.get(), "TimeUUIDType(reversed=true)", ComponentEquality.EQUAL);
-		composite.addComponent(18, "UTF8Text", StringSerializer.get(), "UTF8Type(reversed=true)", ComponentEquality.EQUAL);
-		composite.addComponent(19,  lexUUID, UUIDSerializer.get(), "UUIDType(reversed=true)", ComponentEquality.EQUAL);
-
-        composite.addComponent(20, date, DateSerializer.get(), "DateType(reversed=true)", ComponentEquality.EQUAL);
-        composite.addComponent(21, true, BooleanSerializer.get(), "BooleanType(reversed=true)", ComponentEquality.EQUAL);
-        composite.addComponent(22, 1.1f, FloatSerializer.get(), "FloatType(reversed=true)", ComponentEquality.EQUAL);
-        composite.addComponent(23, 1.2d, DoubleSerializer.get(), "DoubleType(reversed=true)", ComponentEquality.EQUAL);
+    //  new types:    DateType, BooleanType, FloatType, DoubleType
+    composite.addComponent(8, date, DateSerializer.get(), "DateType", ComponentEquality.EQUAL);
+    composite.addComponent(9, true, BooleanSerializer.get(), "BooleanType", ComponentEquality.EQUAL);
+    composite.addComponent(10, 1.1f, FloatSerializer.get(), "FloatType", ComponentEquality.EQUAL);
+    composite.addComponent(11, 1.2d, DoubleSerializer.get(), "DoubleType", ComponentEquality.EQUAL);
 
 
+    //add all reverse comparators
+    composite.addComponent(12, "AsciiText", AsciiSerializer.get(), "AsciiType(reversed=true)", ComponentEquality.EQUAL);
+    composite.addComponent(13, new byte[]{0, 1, 2, 3}, BytesArraySerializer.get(), "BytesType(reversed=true)", ComponentEquality.EQUAL);
+    composite.addComponent(14, -1, IntegerSerializer.get(), "IntegerType(reversed=true)", ComponentEquality.EQUAL);
+    composite.addComponent(15, lexUUID, UUIDSerializer.get(), "LexicalUUIDType(reversed=true)", ComponentEquality.EQUAL);
+    composite.addComponent(16, -1l, LongSerializer.get(), "LongType(reversed=true)", ComponentEquality.EQUAL);
+    composite.addComponent(17, timeUUID, TimeUUIDSerializer.get(), "TimeUUIDType(reversed=true)", ComponentEquality.EQUAL);
+    composite.addComponent(18, "UTF8Text", StringSerializer.get(), "UTF8Type(reversed=true)", ComponentEquality.EQUAL);
+    composite.addComponent(19, lexUUID, UUIDSerializer.get(), "UUIDType(reversed=true)", ComponentEquality.EQUAL);
+
+    composite.addComponent(20, date, DateSerializer.get(), "DateType(reversed=true)", ComponentEquality.EQUAL);
+    composite.addComponent(21, true, BooleanSerializer.get(), "BooleanType(reversed=true)", ComponentEquality.EQUAL);
+    composite.addComponent(22, 1.1f, FloatSerializer.get(), "FloatType(reversed=true)", ComponentEquality.EQUAL);
+    composite.addComponent(23, 1.2d, DoubleSerializer.get(), "DoubleType(reversed=true)", ComponentEquality.EQUAL);
 
 
-		//serialize to the native bytes value
-		
-		ByteBuffer buffer = DynamicCompositeSerializer.get().toByteBuffer(composite);
-		
-	
-		//now deserialize and ensure the values are the same
-		DynamicComposite parsed = DynamicCompositeSerializer.get().fromByteBuffer(buffer);
-		
-		assertEquals("AsciiText", parsed.get(0, AsciiSerializer.get()));
-		assertArrayEquals(new byte[]{0, 1, 2, 3}, parsed.get(1, BytesArraySerializer.get()));
-		assertEquals(Integer.valueOf(-1), parsed.get(2, IntegerSerializer.get()));
-		assertEquals(lexUUID, parsed.get(3, UUIDSerializer.get()));
-		assertEquals(Long.valueOf(-1l), parsed.get(4, LongSerializer.get()));
-		assertEquals(timeUUID, parsed.get(5, TimeUUIDSerializer.get()));
-		assertEquals("UTF8Text", parsed.get(6, StringSerializer.get()));
-		assertEquals(lexUUID, parsed.get(7, UUIDSerializer.get()));
-        assertEquals(date, parsed.get(8, DateSerializer.get()));
-        assertEquals(Boolean.TRUE, parsed.get(9, BooleanSerializer.get()));
-        assertEquals(new Float(1.1f), parsed.get(10, FloatSerializer.get()));
-        assertEquals(new Double(1.2d), parsed.get(11, DoubleSerializer.get()));
+    //serialize to the native bytes value
+
+    ByteBuffer buffer = DynamicCompositeSerializer.get().toByteBuffer(composite);
 
 
-		//now test all the reversed values
-		assertEquals("AsciiText", parsed.get(12, AsciiSerializer.get()));
-		assertArrayEquals(new byte[]{0, 1, 2, 3}, parsed.get(13, BytesArraySerializer.get()));
-		assertEquals(Integer.valueOf(-1), parsed.get(14, IntegerSerializer.get()));
-		assertEquals(lexUUID, parsed.get(15, UUIDSerializer.get()));
-		assertEquals(Long.valueOf(-1l), parsed.get(16, LongSerializer.get()));
-		assertEquals(timeUUID, parsed.get(17, TimeUUIDSerializer.get()));
-		assertEquals("UTF8Text", parsed.get(18, StringSerializer.get()));
-		assertEquals(lexUUID, parsed.get(19, UUIDSerializer.get()));
-        assertEquals(date, parsed.get(20, DateSerializer.get()));
-        assertEquals(Boolean.TRUE, parsed.get(21, BooleanSerializer.get()));
-        assertEquals(new Float(1.1f), parsed.get(22, FloatSerializer.get()));
-        assertEquals(new Double(1.2d), parsed.get(23, DoubleSerializer.get()));
-		
+    //now deserialize and ensure the values are the same
+    DynamicComposite parsed = DynamicCompositeSerializer.get().fromByteBuffer(buffer);
 
-	}
+    assertEquals("AsciiText", parsed.get(0, AsciiSerializer.get()));
+    assertArrayEquals(new byte[]{0, 1, 2, 3}, parsed.get(1, BytesArraySerializer.get()));
+    assertEquals(Integer.valueOf(-1), parsed.get(2, IntegerSerializer.get()));
+    assertEquals(lexUUID, parsed.get(3, UUIDSerializer.get()));
+    assertEquals(Long.valueOf(-1l), parsed.get(4, LongSerializer.get()));
+    assertEquals(timeUUID, parsed.get(5, TimeUUIDSerializer.get()));
+    assertEquals("UTF8Text", parsed.get(6, StringSerializer.get()));
+    assertEquals(lexUUID, parsed.get(7, UUIDSerializer.get()));
+    assertEquals(date, parsed.get(8, DateSerializer.get()));
+    assertEquals(Boolean.TRUE, parsed.get(9, BooleanSerializer.get()));
+    assertEquals(new Float(1.1f), parsed.get(10, FloatSerializer.get()));
+    assertEquals(new Double(1.2d), parsed.get(11, DoubleSerializer.get()));
+
+
+    //now test all the reversed values
+    assertEquals("AsciiText", parsed.get(12, AsciiSerializer.get()));
+    assertArrayEquals(new byte[]{0, 1, 2, 3}, parsed.get(13, BytesArraySerializer.get()));
+    assertEquals(Integer.valueOf(-1), parsed.get(14, IntegerSerializer.get()));
+    assertEquals(lexUUID, parsed.get(15, UUIDSerializer.get()));
+    assertEquals(Long.valueOf(-1l), parsed.get(16, LongSerializer.get()));
+    assertEquals(timeUUID, parsed.get(17, TimeUUIDSerializer.get()));
+    assertEquals("UTF8Text", parsed.get(18, StringSerializer.get()));
+    assertEquals(lexUUID, parsed.get(19, UUIDSerializer.get()));
+    assertEquals(date, parsed.get(20, DateSerializer.get()));
+    assertEquals(Boolean.TRUE, parsed.get(21, BooleanSerializer.get()));
+    assertEquals(new Float(1.1f), parsed.get(22, FloatSerializer.get()));
+    assertEquals(new Double(1.2d), parsed.get(23, DoubleSerializer.get()));
+
+
+  }
 
 }


### PR DESCRIPTION
Switch to builtin cassandra comparator types for the newly native boolean, date, float and double types
added in cassandra 0.8.1. Added support for new types in AbstractComposite.

As discussed on hector-users I ran tests against data written with the old serializers and didn't see 
any differences. (of ByteBuffer.putDouble vs. putLong(Double.doubleToLongBits)
