### PR TITLE
improve casting to be more consistent with interfaces in ThriftCluster

### DIFF
--- a/core/src/main/java/me/prettyprint/cassandra/service/ThriftCluster.java
+++ b/core/src/main/java/me/prettyprint/cassandra/service/ThriftCluster.java
@@ -62,7 +62,7 @@ public class ThriftCluster extends AbstractCluster implements Cluster {
       @Override
       public String execute(Cassandra.Client cassandra) throws HectorException {
         try {
-          String schemaId = cassandra.system_update_keyspace(((ThriftKsDef) ksdef).toThrift());
+          String schemaId = cassandra.system_update_keyspace(toThriftImplementation(ksdef).toThrift());
           if (blockUntilComplete) {
             waitForSchemaAgreement(cassandra);
           }
@@ -90,8 +90,7 @@ public class ThriftCluster extends AbstractCluster implements Cluster {
       @Override
       public String execute(Cassandra.Client cassandra) throws HectorException {
         try {
-        	
-          String schemaId = cassandra.system_add_column_family(((ThriftCfDef) cfdef).toThrift());
+          String schemaId = cassandra.system_add_column_family(toThriftImplementation(cfdef).toThrift());
           if (blockUntilComplete) {
             waitForSchemaAgreement(cassandra);
           }
@@ -119,7 +118,7 @@ public class ThriftCluster extends AbstractCluster implements Cluster {
       @Override
       public String execute(Cassandra.Client cassandra) throws HectorException {
         try {
-          String schemaId = cassandra.system_update_column_family(((ThriftCfDef) cfdef).toThrift());
+          String schemaId = cassandra.system_update_column_family(toThriftImplementation(cfdef).toThrift());
           if (blockUntilComplete) {
             waitForSchemaAgreement(cassandra);
           }
@@ -144,7 +143,7 @@ public class ThriftCluster extends AbstractCluster implements Cluster {
       @Override
       public String execute(Cassandra.Client cassandra) throws HectorException {
         try {
-          String schemaId = cassandra.system_add_keyspace(((ThriftKsDef) ksdef).toThrift());
+          String schemaId = cassandra.system_add_keyspace(toThriftImplementation(ksdef).toThrift());
           if (blockUntilComplete) {
             waitForSchemaAgreement(cassandra);
           }
@@ -157,5 +156,20 @@ public class ThriftCluster extends AbstractCluster implements Cluster {
     connectionManager.operateWithFailover(op);
     return op.getResult();
   }
-
+  
+  private ThriftCfDef toThriftImplementation(final ColumnFamilyDefinition cfdef) {
+  	if(cfdef instanceof ThriftCfDef) {
+  	  return (ThriftCfDef) cfdef;
+  	} else {
+  	  return new ThriftCfDef(cfdef);
+  	}
+  }
+  
+  private ThriftKsDef toThriftImplementation(final KeyspaceDefinition cfdef) {
+  	if(cfdef instanceof ThriftKsDef) {
+  	  return (ThriftKsDef) cfdef;
+  	} else {
+  	  return new ThriftKsDef(cfdef);
+  	}
+  }
 }

--- a/core/src/test/java/me/prettyprint/cassandra/service/CassandraClusterTest.java
+++ b/core/src/test/java/me/prettyprint/cassandra/service/CassandraClusterTest.java
@@ -11,6 +11,7 @@ import java.util.List;
 import me.prettyprint.cassandra.BaseEmbededServerSetupTest;
 import me.prettyprint.cassandra.model.BasicColumnDefinition;
 import me.prettyprint.cassandra.model.BasicColumnFamilyDefinition;
+import me.prettyprint.cassandra.model.BasicKeyspaceDefinition;           
 import me.prettyprint.cassandra.serializers.StringSerializer;
 import me.prettyprint.hector.api.Keyspace;
 import me.prettyprint.hector.api.ddl.ColumnFamilyDefinition;
@@ -197,4 +198,71 @@ public class CassandraClusterTest extends BaseEmbededServerSetupTest {
     assertNotNull(ksid2);
   }
   
+  @Test
+  public void testAddEmptyBasicKeyspaceDefinition() throws Exception {
+    BasicKeyspaceDefinition ksDef = new BasicKeyspaceDefinition();
+    ksDef.setName("DynKeyspaceEmpty");
+    ksDef.setReplicationFactor(1);
+    ksDef.setStrategyClass("SimpleStrategy");
+    
+    cassandraCluster.addKeyspace(ksDef);
+    assertNotNull(cassandraCluster.describeKeyspace("DynKeyspaceEmpty"));
+    String ksid2 = cassandraCluster.dropKeyspace("DynKeyspaceEmpty");
+    assertNotNull(ksid2);
+  }
+  
+  @Test
+  public void testEditBasicKeyspaceDefinition() throws Exception {
+    BasicKeyspaceDefinition ksDef = new BasicKeyspaceDefinition();
+    ksDef.setName("DynKeyspace4");
+    ksDef.setReplicationFactor(1);
+    ksDef.setStrategyClass("SimpleStrategy");
+    
+    cassandraCluster.addKeyspace(ksDef);
+    assertNotNull(cassandraCluster.describeKeyspace("DynKeyspace4"));
+    
+    ksDef.setReplicationFactor(2);
+    
+    cassandraCluster.updateKeyspace(ksDef);
+    
+    KeyspaceDefinition fromCluster = cassandraCluster.describeKeyspace("DynKeyspace4");
+    assertEquals(2, fromCluster.getReplicationFactor());
+    cassandraCluster.dropKeyspace("DynKeyspace4");
+  }
+  
+  @Test
+  public void testAddDropBasicColumnFamilyDefinition() throws Exception {
+    BasicColumnFamilyDefinition cfDef = new BasicColumnFamilyDefinition();
+    cfDef.setName("DynCf");
+    cfDef.setKeyspaceName("Keyspace1");
+
+    cassandraCluster.addColumnFamily(cfDef);
+    String cfid2 = cassandraCluster.dropColumnFamily("Keyspace1", "DynCf");
+    assertNotNull(cfid2);
+  }
+  
+  @Test
+  public void testEditBasicColumnFamilyDefinition() throws Exception {
+    BasicKeyspaceDefinition ksDef = new BasicKeyspaceDefinition();
+    ksDef.setName("Keyspace2");
+    ksDef.setReplicationFactor(1);
+    ksDef.setStrategyClass("SimpleStrategy");
+    
+    cassandraCluster.addKeyspace(ksDef);
+    
+    BasicColumnFamilyDefinition cfDef = new BasicColumnFamilyDefinition();
+    cfDef.setName("DynCf2");
+    cfDef.setKeyspaceName("Keyspace2");
+
+    cassandraCluster.addColumnFamily(cfDef);
+    
+    KeyspaceDefinition fromCluster = cassandraCluster.describeKeyspace("Keyspace2");    
+    cfDef = new BasicColumnFamilyDefinition(fromCluster.getCfDefs().get(0));
+    
+    cfDef.setDefaultValidationClass(ComparatorType.LONGTYPE.getClassName());
+    cassandraCluster.updateColumnFamily(cfDef);
+    
+    String cfid2 = cassandraCluster.dropColumnFamily("Keyspace2", "DynCf2");
+    assertNotNull(cfid2);
+  }
 }


### PR DESCRIPTION
ThriftCluster uses interfaces to type definition in add and update methods but assumes that thrift implementations are always used. This patch improves the casting to be more consistent with interfaces.
