### PR TITLE
if a HThriftClient fails to add_keyspace, this error will always prevent future operations 

### DIFF
--- a/core/src/main/java/me/prettyprint/cassandra/connection/HThriftClient.java
+++ b/core/src/main/java/me/prettyprint/cassandra/connection/HThriftClient.java
@@ -63,14 +63,14 @@ public class HThriftClient {
     if ( keyspaceNameArg != null && !StringUtils.equals(keyspaceName, keyspaceNameArg)) {
       if ( log.isDebugEnabled() )
         log.debug("keyspace reseting from {} to {}", keyspaceName, keyspaceNameArg);
-      keyspaceName = keyspaceNameArg;
       try {
-        cassandraClient.set_keyspace(keyspaceName);        
+        cassandraClient.set_keyspace(keyspaceNameArg);        
       } catch (InvalidRequestException ire) {
         throw new HInvalidRequestException(ire);
       } catch (TException e) {
         throw new HectorTransportException(e);
       } 
+      keyspaceName = keyspaceNameArg;
 
     }
     return cassandraClient;


### PR DESCRIPTION
let's say we start from an empty cassandra cluster

you use a HFactory to create HCluster, and operate on a keyspace.
since no keyspace exists, the HThriftClient.getCassandra() will fail at set_keyspace(), but now the remembered ks is already changed, so in the future it will never try to do set_keyspace() again, so we will get
errors on cassandra server saying that the server end Thread-local ks is not set.
