### PR TITLE
JmxMonitor throws NullPointerException during cluster initialization

### DIFF
--- a/core/src/main/java/me/prettyprint/cassandra/service/JmxMonitor.java
+++ b/core/src/main/java/me/prettyprint/cassandra/service/JmxMonitor.java
@@ -96,7 +96,10 @@ public class JmxMonitor {
    * @return A string representing the current context path or null if it cannot be determined.
    */
   private String getContextPath() {
-    URL url = getClass().getClassLoader().getResource("/");
+    ClassLoader loader = getClass().getClassLoader();
+    if(loader == null)
+     return null;
+    URL url = loader.getResource("/");
     if (url != null) {
       String[] elements = url.toString().split("/");
       for (int i = elements.length - 1; i > 0; --i) {


### PR DESCRIPTION
Hi, 

I got a NullPointerException when using HFactory.getOrCreateCluster. Actually getClass().getClassLoader() may be null on some platforms. This causes JmxMonitor.getContextPath() throws NullPointerException.

Ref:
http://download.oracle.com/javase/6/docs/api/java/lang/Class.html#getClassLoader()

Thanks.
