### PR TITLE
Iterator's next() was being called without checking hasNext()

### DIFF
--- a/core/src/main/java/me/prettyprint/cassandra/service/template/ColumnFamilyResultWrapper.java
+++ b/core/src/main/java/me/prettyprint/cassandra/service/template/ColumnFamilyResultWrapper.java
@@ -38,7 +38,10 @@ public class ColumnFamilyResultWrapper<K,N> extends AbstractResultWrapper<K,N> {
       ExecutionResult<Map<ByteBuffer,List<ColumnOrSuperColumn>>> executionResult) {
     super(keySerializer, columnNameSerializer, executionResult);    
     this.rows = executionResult.get().entrySet().iterator();    
-    next();
+		if(hasNext()) {
+			next();
+		}
+
     hasEntries = getColumnNames() != null && getColumnNames().size() > 0;
   }
    


### PR DESCRIPTION
When calling template.queryColumns(keys), a NoSuchElementException was being thrown.  The constructor was calling next() on the row iterator without first checking hasNext().
