### PR TITLE
Fixed NullPointerException

### DIFF
--- a/core/src/main/java/me/prettyprint/cassandra/service/template/ColumnFamilyResultWrapper.java
+++ b/core/src/main/java/me/prettyprint/cassandra/service/template/ColumnFamilyResultWrapper.java
@@ -50,7 +50,7 @@ public class ColumnFamilyResultWrapper<K,N> extends AbstractResultWrapper<K,N> {
    * @return
    */
   public Collection<N> getColumnNames() {
-    return columns.keySet();
+    return columns == null ? null : columns.keySet();
   }
   
   public ByteBuffer getColumnValue( N columnName) {


### PR DESCRIPTION
ColumnFamilyResultWrapper was throwing a NullPointerException when getting the column names if there are no columns.
