### PR TITLE
Bugfix in JaxbSerializer

### DIFF
--- a/core/src/main/java/me/prettyprint/cassandra/serializers/JaxbSerializer.java
+++ b/core/src/main/java/me/prettyprint/cassandra/serializers/JaxbSerializer.java
@@ -110,7 +110,7 @@ public class JaxbSerializer extends AbstractSerializer<Object> {
       return null;
     }
 
-    ByteArrayInputStream bais = new ByteArrayInputStream(bytes.array());
+    ByteArrayInputStream bais = new ByteArrayInputStream(bytes.array(), bytes.position(), bytes.remaining());
     try {
       XMLStreamReader reader = createStreamReader(bais);
       Object ret = unmarshaller.get().unmarshal(reader);


### PR DESCRIPTION
The JaxbSerializer should take only the defined part of the ByteBuffer for deserializing. This is a small fix for against this Problem.
