### PR TITLE
This is a fix for the way the composite id's are created when loading an object

### DIFF
--- a/object-mapper/src/main/java/me/prettyprint/hom/HectorObjectMapper.java
+++ b/object-mapper/src/main/java/me/prettyprint/hom/HectorObjectMapper.java
@@ -207,21 +207,13 @@ public class HectorObjectMapper {
   private byte[] generateColumnFamilyKeyFromPkObj(CFMappingDef<?> cfMapDef, Object pkObj) {
     List<byte[]> segmentList = new ArrayList<byte[]>(cfMapDef.getKeyDef().getIdPropertyMap().size());
     
-    List<String> rm1 = new ArrayList<String>();
-    List<String> rm2 = new ArrayList<String>();
-    
-    if (cfMapDef.getKeyDef().isComplexKey()) {
-    	
-      Map<String, PropertyDescriptor> propertyDescriptorMap = cfMapDef.getKeyDef().getPropertyDescriptorMap(); 	
-      Map<String, PropertyMappingDefinition> idPropertyMap =  cfMapDef.getKeyDef().getIdPropertyMap();
-    	
+    if (cfMapDef.getKeyDef().isComplexKey()) {	
+      Map<String, PropertyDescriptor> propertyDescriptorMap = cfMapDef.getKeyDef().getPropertyDescriptorMap(); 	 
       for (String key : cfMapDef.getKeyDef().getIdPropertyMap().keySet()) {
     	  PropertyDescriptor pd = propertyDescriptorMap.get(key);
     	  segmentList.add(callMethodAndConvertToCassandraType(pkObj, pd.getReadMethod(),
     	            new DefaultConverter()));
-      }
-     
-    	 
+      }	 
     } else {
       PropertyMappingDefinition md = cfMapDef.getKeyDef().getIdPropertyMap().values().iterator()
                                              .next();

--- a/object-mapper/src/test/java/me/prettyprint/hom/CassandraTestBase.java
+++ b/object-mapper/src/test/java/me/prettyprint/hom/CassandraTestBase.java
@@ -102,6 +102,8 @@ public class CassandraTestBase {
             .setKey_cache_size(0).setRow_cache_size(0).setGc_grace_seconds(86400));
         cfDefList.add(new CfDef("TestKeyspace", "ComplexColumnFamily").setComparator_type(BytesType.class.getSimpleName())
             .setKey_cache_size(0).setRow_cache_size(0).setGc_grace_seconds(86400));
+        cfDefList.add(new CfDef("TestKeyspace", "CompositeColumnFamily").setComparator_type(BytesType.class.getSimpleName())
+                .setKey_cache_size(0).setRow_cache_size(0).setGc_grace_seconds(86400));
         cfDefList.add(new CfDef("TestKeyspace", "Furniture").setComparator_type(BytesType.class.getSimpleName())
             .setKey_cache_size(0).setRow_cache_size(0).setGc_grace_seconds(86400));
         cfDefList.add(new CfDef("TestKeyspace", "MyConvertedCollectionFamily").setComparator_type(BytesType.class.getSimpleName())

--- a/object-mapper/src/test/java/me/prettyprint/hom/EntityManagerTest.java
+++ b/object-mapper/src/test/java/me/prettyprint/hom/EntityManagerTest.java
@@ -1,5 +1,10 @@
 package me.prettyprint.hom;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map.Entry;
@@ -13,6 +18,8 @@ import me.prettyprint.hector.api.mutation.Mutator;
 import me.prettyprint.hom.beans.AnonymousWithCustomType;
 import me.prettyprint.hom.beans.MyBlueTestBean;
 import me.prettyprint.hom.beans.MyComplexEntity;
+import me.prettyprint.hom.beans.MyComposite2PK;
+import me.prettyprint.hom.beans.MyCompositeEntity;
 import me.prettyprint.hom.beans.MyCompositePK;
 import me.prettyprint.hom.beans.MyConvertedCollectionBean;
 import me.prettyprint.hom.beans.MyCustomIdBean;
@@ -25,11 +32,6 @@ import me.prettyprint.hom.beans.MyTestBeanNoAnonymous;
 import org.junit.Test;
 
 import com.mycompany.furniture.Drawer;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 public class EntityManagerTest extends CassandraTestBase {
 
@@ -136,6 +138,26 @@ public class EntityManagerTest extends CassandraTestBase {
     assertEquals(entity1.getDrawer(), entity2.getDrawer());
   }
 
+  @Test
+  public void testPersistAndFindCompositeType() {
+    EntityManagerImpl em = new EntityManagerImpl(keyspace, "me.prettyprint.hom.beans");
+    MyComposite2PK pkKey = new MyComposite2PK("str-prop", 1);
+    MyCompositeEntity entity1 = new MyCompositeEntity();
+    entity1.setIntProp1(pkKey.getIntProp1());
+    entity1.setStrProp1(pkKey.getStrProp1());
+    entity1.setStrProp2("str-prop-two");
+    entity1.setDrawer(new Drawer(true, false, "a very nice drawer"));
+
+    em.persist(entity1);
+
+    MyCompositeEntity entity2 = em.find(MyCompositeEntity.class, pkKey);
+
+    assertEquals(entity1.getIntProp1(), entity2.getIntProp1());
+    assertEquals(entity1.getStrProp1(), entity2.getStrProp1());
+    assertEquals(entity1.getStrProp2(), entity2.getStrProp2());
+    assertEquals(entity1.getDrawer(), entity2.getDrawer());
+  }
+  
   @Test
   public void testMissingColumnsForPojoProps() {
     // Mutator<Long> m = HFactory.createMutator(keyspace, LongSerializer.get());

--- a/object-mapper/src/test/java/me/prettyprint/hom/HectorObjectMapperTest.java
+++ b/object-mapper/src/test/java/me/prettyprint/hom/HectorObjectMapperTest.java
@@ -21,6 +21,7 @@ import me.prettyprint.cassandra.serializers.UUIDSerializer;
 import me.prettyprint.hector.api.beans.HColumn;
 import me.prettyprint.hom.annotations.AnonymousPropertyHandling;
 import me.prettyprint.hom.beans.MyComplexEntity;
+import me.prettyprint.hom.beans.MyCompositeEntity;
 import me.prettyprint.hom.beans.MyConvertedCollectionBean;
 import me.prettyprint.hom.beans.MyCustomIdBean;
 import me.prettyprint.hom.beans.MyTestBean;
@@ -207,6 +208,7 @@ public class HectorObjectMapperTest {
     cacheMgr.initializeCacheForClass(MyTestBean.class);
     cacheMgr.initializeCacheForClass(MyCustomIdBean.class);
     cacheMgr.initializeCacheForClass(MyComplexEntity.class);
+    cacheMgr.initializeCacheForClass(MyCompositeEntity.class);
     cacheMgr.initializeCacheForClass(MyConvertedCollectionBean.class);
     cacheMgr.initializeCacheForClass(AnonymousWithLongSerializer.class);
   }

--- a/object-mapper/src/test/java/me/prettyprint/hom/beans/MyComposite2PK.java
+++ b/object-mapper/src/test/java/me/prettyprint/hom/beans/MyComposite2PK.java
@@ -1,0 +1,40 @@
+package me.prettyprint.hom.beans;
+
+import java.io.Serializable;
+
+/**
+ * Used with @IdClass. Properties of this class must match @Id properties
+ * defined by the entity.
+ * 
+ * @author B. Todd Burruss
+ */
+@SuppressWarnings("serial")
+public class MyComposite2PK implements Serializable {
+
+	private String strProp1;
+	private int intProp1;
+
+	public MyComposite2PK() {
+	}
+
+	public MyComposite2PK(String strProp1, int intProp1) {
+		this.intProp1 = intProp1;
+		this.strProp1 = strProp1;
+	}
+
+	public int getIntProp1() {
+		return intProp1;
+	}
+
+	public void setIntProp1(int intProp1) {
+		this.intProp1 = intProp1;
+	}
+
+	public String getStrProp1() {
+		return strProp1;
+	}
+
+	public void setStrProp1(String strProp1) {
+		this.strProp1 = strProp1;
+	}
+}

--- a/object-mapper/src/test/java/me/prettyprint/hom/beans/MyCompositeEntity.java
+++ b/object-mapper/src/test/java/me/prettyprint/hom/beans/MyCompositeEntity.java
@@ -1,0 +1,71 @@
+package me.prettyprint.hom.beans;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.IdClass;
+import javax.persistence.Table;
+
+import com.mycompany.furniture.Drawer;
+
+@Entity
+@IdClass(MyComposite2PK.class)
+@Table(name = "CompositeColumnFamily")
+public class MyCompositeEntity {
+
+	@Id
+	private String strProp1;
+	
+	@Id
+	private int intProp1;
+
+	@Column(name = "strProp2")
+	private String strProp2;
+
+	@Column(name = "strProp3")
+	private String strProp3;
+
+	@Column(name = "drawer")
+	private Drawer drawer;
+
+	public int getIntProp1() {
+		return intProp1;
+	}
+
+	public void setIntProp1(int intProp1) {
+		this.intProp1 = intProp1;
+	}
+
+	public String getStrProp1() {
+		return strProp1;
+	}
+
+	public void setStrProp1(String strProp1) {
+		this.strProp1 = strProp1;
+	}
+
+	public String getStrProp2() {
+		return strProp2;
+	}
+
+	public void setStrProp2(String strProp2) {
+		this.strProp2 = strProp2;
+	}
+
+	public String getStrProp3() {
+		return strProp3;
+	}
+
+	public void setStrProp3(String strProp3) {
+		this.strProp3 = strProp3;
+	}
+
+	public Drawer getDrawer() {
+		return drawer;
+	}
+
+	public void setDrawer(Drawer drawer) {
+		this.drawer = drawer;
+	}
+
+}


### PR DESCRIPTION
A problem occurred when you attempted to find an object by composite
key. The composite would be persisted in order by the order of the
composite fields in the class. When attempting to find the object the
objectMapper would use the natural ordering of the field names instead.

I have added test cases that will fail when this update is not added, and pass when added.
