### PR TITLE
Issue 349

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -105,20 +105,6 @@
       <artifactId>cassandra-thrift</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.thrift</groupId>
-      <artifactId>libthrift</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>javax.servlet</groupId>
-          <artifactId>servlet-api</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.apache.httpcomponents</groupId>
-          <artifactId>httpclient</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -103,11 +103,6 @@
         <version>1.0.6</version>
       </dependency>
       <dependency>
-        <groupId>org.apache.thrift</groupId>
-        <artifactId>libthrift</artifactId>
-        <version>0.6.1</version>
-      </dependency>
-      <dependency>
         <groupId>commons-lang</groupId>
         <artifactId>commons-lang</artifactId>
         <version>2.4</version>


### PR DESCRIPTION
Fix for issue #349: removing libthrift dependency since cassandra-thrift pulls in the correct version of thrift currently in use by server. 

-Jake
