### PR TITLE
Fix NPE in DoubleSerializer for nonexistent columns

### DIFF
--- a/core/src/main/java/me/prettyprint/cassandra/serializers/DoubleSerializer.java
+++ b/core/src/main/java/me/prettyprint/cassandra/serializers/DoubleSerializer.java
@@ -20,12 +20,16 @@ public class DoubleSerializer extends AbstractSerializer<Double> {
   
   @Override
   public ByteBuffer toByteBuffer(Double obj) {
+    if (obj == null) {
+      return null;
+    }
     return LongSerializer.get().toByteBuffer(Double.doubleToRawLongBits(obj));
   }
 
   @Override
   public Double fromByteBuffer(ByteBuffer bytes) {
-    return Double.longBitsToDouble (LongSerializer.get().fromByteBuffer(bytes));
+    Long l = LongSerializer.get().fromByteBuffer(bytes);
+    return l == null ? null : Double.longBitsToDouble (l);
   }
 
 }


### PR DESCRIPTION
DoubleSerializer uses LongSerializer internally. However whenever LongSerializer returns null (such as when the column does not exist) this would cause a NullPointerException.

Here I add some guards similar to what already exist in LongSerializer.
