### PR TITLE
Can't easily specify an empty startKey in IndexedSlicesPredicate

### DIFF
--- a/core/src/main/java/me/prettyprint/cassandra/service/template/IndexedSlicesPredicate.java
+++ b/core/src/main/java/me/prettyprint/cassandra/service/template/IndexedSlicesPredicate.java
@@ -40,6 +40,9 @@ public class IndexedSlicesPredicate<K,N,V> {
     return this;
   }
   public IndexClause toThrift() {
+    if (!indexClause.isSetStart_key()) {
+        indexClause.setStart_key(new byte[0]);
+    }
     return indexClause;
   }
 }


### PR DESCRIPTION
This patch makes startKey an empty ByteBuffer by default for IndexedSlicesPredicate.

This mimics the behavior of IndexedSliceQuery, and allows users to easily specify an empty startKey in the case of key types such as UUID that don't make it easy to get an "empty" value by simply not setting the startKey.
