### PR TITLE
Fix round-tripping of empty String Component in Composite

### DIFF
--- a/core/src/main/java/me/prettyprint/hector/api/beans/AbstractComposite.java
+++ b/core/src/main/java/me/prettyprint/hector/api/beans/AbstractComposite.java
@@ -142,9 +142,7 @@ public abstract class AbstractComposite extends AbstractList<Object> implements
       }
       if ((value == null) && (bytes != null) && (s != null)) {
         ByteBuffer cb = bytes.duplicate();
-        if (cb.hasRemaining()) {
-          return s.fromByteBuffer(cb);
-        }
+        return s.fromByteBuffer(cb);
       }
       if (value instanceof ByteBuffer) {
         return (A) ((ByteBuffer) value).duplicate();
@@ -457,6 +455,10 @@ public abstract class AbstractComposite extends AbstractList<Object> implements
       Serializer<T> s, String comparator, ComponentEquality equality) {
     serialized = null;
 
+    if (value == null) {
+        throw new NullPointerException("Unable able to add null component");
+    }
+        
     if (index < 0) {
       index = components.size();
     }


### PR DESCRIPTION
I have a Composite column family with a component string that may be empty. I notice that when I store a value with an empty string, the value comes back as a null string, rather than being empty (""). The value is serialized as a zero-length ByteBuffer and Cassandra round trips that properly, but AbstractComposite.getValue() specials cases an empty ByteBuffer, rather than letting the serializer handle it. When I removed the special case, ComnpositeTest.testNullValueSerialization() fails, because nulls don't round trip properly. I resolved the issue in my commit by throwing an NPE when a null component is added to a Composite, but another approach might be better.

Thoughts?
