### PR TITLE
Weird errors here. But compiles cleanly against Cassandra. Most tests work. 1.1

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -101,6 +101,13 @@
       <groupId>commons-pool</groupId>
       <artifactId>commons-pool</artifactId>
     </dependency>
+
+   <!--for abstract types? -->
+        <dependency>
+              <groupId>org.apache.cassandra</groupId>
+                    <artifactId>cassandra-all</artifactId>
+                        </dependency>
+
     <dependency>
       <groupId>org.apache.cassandra</groupId>
       <artifactId>cassandra-thrift</artifactId>

--- a/core/src/main/java/me/prettyprint/cassandra/model/thrift/AbstractThriftClientWrapper.java
+++ b/core/src/main/java/me/prettyprint/cassandra/model/thrift/AbstractThriftClientWrapper.java
@@ -388,7 +388,7 @@ public abstract class AbstractThriftClientWrapper extends Client {
 
   @Override
   public void recv_truncate() throws InvalidRequestException,
-      UnavailableException, TException {
+      UnavailableException, TException, TimedOutException {
     client.recv_truncate();
   }
 
@@ -632,7 +632,7 @@ public abstract class AbstractThriftClientWrapper extends Client {
 
   @Override
   public void truncate(String cfname) throws InvalidRequestException,
-      UnavailableException, TException {
+      UnavailableException, TException, TimedOutException {
     client.truncate(cfname);
   }
 }

--- a/core/src/test/java/me/prettyprint/hector/api/CompositeTest.java
+++ b/core/src/test/java/me/prettyprint/hector/api/CompositeTest.java
@@ -1,5 +1,6 @@
 package me.prettyprint.hector.api;
 
+import java.util.UUID;
 import static me.prettyprint.hector.api.ddl.ComparatorType.UUIDTYPE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -20,7 +21,6 @@ import me.prettyprint.cassandra.utils.TimeUUIDUtils;
 import me.prettyprint.hector.api.beans.AbstractComposite.ComponentEquality;
 import me.prettyprint.hector.api.beans.Composite;
 import me.prettyprint.hector.api.beans.DynamicComposite;
-
 import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.db.marshal.AsciiType;
 import org.apache.cassandra.db.marshal.BytesType;
@@ -33,6 +33,7 @@ import org.apache.cassandra.db.marshal.UTF8Type;
 import org.apache.cassandra.db.marshal.UUIDType;
 import org.apache.cassandra.utils.ByteBufferUtil;
 import org.apache.cassandra.utils.UUIDGen;
+
 import org.junit.Test;
 
 public class CompositeTest {
@@ -245,6 +246,7 @@ public class CompositeTest {
       if (uuid != null) {
         bb.putShort((short) (0x8000 | 't'));
         bb.putShort((short) 16);
+
         bb.put(UUIDGen.decompose(uuid));
         bb.put((i == -1) && lastIsOne ? (byte) 1 : (byte) 0);
         if (i != -1) {
@@ -306,7 +308,8 @@ public class CompositeTest {
 
   @SuppressWarnings("rawtypes")
   public DynamicCompositeType getDefaultDynamicComparator() {
-    Map<Byte, AbstractType> aliases = new HashMap<Byte, AbstractType>();
+    //Well if ? makes you happy then :) Generics FTWhatever
+    Map<Byte, AbstractType<?>> aliases = new HashMap<Byte, AbstractType<?>>();
     aliases.put((byte) 'a', AsciiType.instance);
     aliases.put((byte) 'b', BytesType.instance);
     aliases.put((byte) 'i', IntegerType.instance);

--- a/core/src/test/resources/cassandra.yaml
+++ b/core/src/test/resources/cassandra.yaml
@@ -1,9 +1,9 @@
 # Cassandra storage config YAML 
 
-#NOTE !!!!!!!! NOTE 
-# See http://wiki.apache.org/cassandra/StorageConfiguration for
-# full explanations of configuration directives
-#NOTE !!!!!!!! NOTE 
+# NOTE:
+#   See http://wiki.apache.org/cassandra/StorageConfiguration for
+#   full explanations of configuration directives
+# /NOTE
 
 # The name of the cluster. This is mainly used to prevent machines in
 # one logical cluster from joining another.
@@ -21,16 +21,13 @@ cluster_name: 'Test Cluster'
 # a random token, which will lead to hot spots.
 initial_token:
 
-# Set to true to make new [non-seed] nodes automatically migrate data
-# to themselves from the pre-existing nodes in the cluster.  Defaults
-# to false because you can only bootstrap N machines at a time from
-# an existing cluster of N, so if you are bringing up a cluster of
-# 10 machines with 3 seeds you would have to do it in stages.  Leaving
-# this off for the initial start simplifies that.
-auto_bootstrap: false
-
 # See http://wiki.apache.org/cassandra/HintedHandoff
 hinted_handoff_enabled: true
+# this defines the maximum amount of time a dead host will have hints
+# generated.  After it has been dead this long, hints will be dropped.
+max_hint_window_in_ms: 3600000 # one hour
+# Sleep this long after delivering each hint
+hinted_handoff_throttle_delay_in_ms: 1
 
 # authentication backend, implementing IAuthenticator; used to identify users
 authenticator: org.apache.cassandra.auth.AllowAllAuthenticator
@@ -38,64 +35,181 @@ authenticator: org.apache.cassandra.auth.AllowAllAuthenticator
 # authorization backend, implementing IAuthority; used to limit access/provide permissions
 authority: org.apache.cassandra.auth.AllowAllAuthority
 
-# any IPartitioner may be used, including your own as long as it is on
-# the classpath.  Out of the box, Cassandra provides
-# org.apache.cassandra.dht.RandomPartitioner
+# The partitioner is responsible for distributing rows (by key) across
+# nodes in the cluster.  Any IPartitioner may be used, including your
+# own as long as it is on the classpath.  Out of the box, Cassandra
+# provides org.apache.cassandra.dht.RandomPartitioner
 # org.apache.cassandra.dht.ByteOrderedPartitioner,
-# org.apache.cassandra.dht.OrderPreservingPartitioner, and
-# org.apache.cassandra.dht.CollatingOrderPreservingPartitioner.
-# (CollatingOPP colates according to EN,US rules, not naive byte
-# ordering.  Use this as an example if you need locale-aware collation.)
-partitioner: org.apache.cassandra.dht.OrderPreservingPartitioner
+# org.apache.cassandra.dht.OrderPreservingPartitioner (deprecated),
+# and org.apache.cassandra.dht.CollatingOrderPreservingPartitioner
+# (deprecated).
+# 
+# - RandomPartitioner distributes rows across the cluster evenly by md5.
+#   When in doubt, this is the best option.
+# - ByteOrderedPartitioner orders rows lexically by key bytes.  BOP allows
+#   scanning rows in key order, but the ordering can generate hot spots
+#   for sequential insertion workloads.
+# - OrderPreservingPartitioner is an obsolete form of BOP, that stores
+# - keys in a less-efficient format and only works with keys that are
+#   UTF8-encoded Strings.
+# - CollatingOPP colates according to EN,US rules rather than lexical byte
+#   ordering.  Use this as an example if you need custom collation.
+#
+# See http://wiki.apache.org/cassandra/Operations for more on
+# partitioners and token selection.
+partitioner: org.apache.cassandra.dht.RandomPartitioner
 
 # directories where Cassandra should store data on disk.
 data_file_directories:
-    - tmp/var/lib/cassandra/data
+    - /var/lib/cassandra/data
 
 # commit log
-commitlog_directory: tmp/var/lib/cassandra/commitlog
+commitlog_directory: /var/lib/cassandra/commitlog
+
+# Maximum size of the key cache in memory.
+#
+# Each key cache hit saves 1 seek and each row cache hit saves 2 seeks at the
+# minimum, sometimes more. The key cache is fairly tiny for the amount of
+# time it saves, so it's worthwhile to use it at large numbers.
+# The row cache saves even more time, but must store the whole values of
+# its rows, so it is extremely space-intensive. It's best to only use the
+# row cache if you have hot rows or static rows.
+#
+# NOTE: if you reduce the size, you may not get you hottest keys loaded on startup.
+#
+# Default value is empty to make it "auto" (min(5% of Heap (in MB), 100MB)). Set to 0 to disable key cache.
+key_cache_size_in_mb:
+
+# Duration in seconds after which Cassandra should
+# safe the keys cache. Caches are saved to saved_caches_directory as
+# specified in this configuration file.
+#
+# Saved caches greatly improve cold-start speeds, and is relatively cheap in
+# terms of I/O for the key cache. Row cache saving is much more expensive and
+# has limited use.
+#
+# Default is 14400 or 4 hours.
+key_cache_save_period: 14400
+
+# Number of keys from the key cache to save
+# Disabled by default, meaning all keys are going to be saved
+# key_cache_keys_to_save: 100
+
+# Maximum size of the row cache in memory.
+# NOTE: if you reduce the size, you may not get you hottest keys loaded on startup.
+#
+# Default value is 0, to disable row caching.
+row_cache_size_in_mb: 0
+
+# Duration in seconds after which Cassandra should
+# safe the row cache. Caches are saved to saved_caches_directory as specified
+# in this configuration file.
+#
+# Saved caches greatly improve cold-start speeds, and is relatively cheap in
+# terms of I/O for the key cache. Row cache saving is much more expensive and
+# has limited use.
+#
+# Default is 0 to disable saving the row cache.
+row_cache_save_period: 0
+
+# Number of keys from the row cache to save
+# Disabled by default, meaning all keys are going to be saved
+# row_cache_keys_to_save: 100
+
+# The provider for the row cache to use.
+#
+# Supported values are: ConcurrentLinkedHashCacheProvider, SerializingCacheProvider
+#
+# SerializingCacheProvider serialises the contents of the row and stores
+# it in native memory, i.e., off the JVM Heap. Serialized rows take
+# significantly less memory than "live" rows in the JVM, so you can cache
+# more rows in a given memory footprint.  And storing the cache off-heap
+# means you can use smaller heap sizes, reducing the impact of GC pauses.
+#
+# It is also valid to specify the fully-qualified class name to a class
+# that implements org.apache.cassandra.cache.IRowCacheProvider.
+#
+# Defaults to SerializingCacheProvider
+row_cache_provider: SerializingCacheProvider
 
 # saved caches
-saved_caches_directory: tmp/var/lib/cassandra/saved_caches
-
+saved_caches_directory: /var/lib/cassandra/saved_caches
 
 # commitlog_sync may be either "periodic" or "batch." 
 # When in batch mode, Cassandra won't ack writes until the commit log
 # has been fsynced to disk.  It will wait up to
-# CommitLogSyncBatchWindowInMS milliseconds for other writes, before
+# commitlog_sync_batch_window_in_ms milliseconds for other writes, before
 # performing the sync.
-commitlog_sync: periodic
-
-# the other option is "timed," where writes may be acked immediately
+#
+# commitlog_sync: batch
+# commitlog_sync_batch_window_in_ms: 50
+#
+# the other option is "periodic" where writes may be acked immediately
 # and the CommitLog is simply synced every commitlog_sync_period_in_ms
 # milliseconds.
+commitlog_sync: periodic
 commitlog_sync_period_in_ms: 10000
 
-# Addresses of hosts that are deemed contact points. 
-# Cassandra nodes use this list of hosts to find each other and learn
-# the topology of the ring.  You must change this if you are running
-# multiple nodes!
+# any class that implements the SeedProvider interface and has a
+# constructor that takes a Map<String, String> of parameters will do.
 seed_provider:
+    # Addresses of hosts that are deemed contact points. 
+    # Cassandra nodes use this list of hosts to find each other and learn
+    # the topology of the ring.  You must change this if you are running
+    # multiple nodes!
     - class_name: org.apache.cassandra.locator.SimpleSeedProvider
       parameters:
+          # seeds is actually a comma-delimited list of addresses.
+          # Ex: "<ip1>,<ip2>,<ip3>"
           - seeds: "127.0.0.1"
-# Access mode.  mmapped i/o is substantially faster, but only practical on
-# a 64bit machine (which notably does not include EC2 "small" instances)
-# or relatively small datasets.  "auto", the safe choice, will enable
-# mmapping on a 64bit JVM.  Other values are "mmap", "mmap_index_only"
-# (which may allow you to get part of the benefits of mmap on a 32bit
-# machine by mmapping only index files) and "standard".
-# (The buffer size settings that follow only apply to standard,
-# non-mmapped i/o.)
-disk_access_mode: auto
 
-# Unlike most systems, in Cassandra writes are faster than reads, so
-# you can afford more of those in parallel.  A good rule of thumb is 2
-# concurrent reads per processor core.  Increase ConcurrentWrites to
-# the number of clients writing at once if you enable CommitLogSync +
-# CommitLogSyncDelay. -->
-concurrent_reads: 2
-concurrent_writes: 4
+# emergency pressure valve: each time heap usage after a full (CMS)
+# garbage collection is above this fraction of the max, Cassandra will
+# flush the largest memtables.  
+#
+# Set to 1.0 to disable.  Setting this lower than
+# CMSInitiatingOccupancyFraction is not likely to be useful.
+#
+# RELYING ON THIS AS YOUR PRIMARY TUNING MECHANISM WILL WORK POORLY:
+# it is most effective under light to moderate load, or read-heavy
+# workloads; under truly massive write load, it will often be too
+# little, too late.
+flush_largest_memtables_at: 0.75
+
+# emergency pressure valve #2: the first time heap usage after a full
+# (CMS) garbage collection is above this fraction of the max,
+# Cassandra will reduce cache maximum _capacity_ to the given fraction
+# of the current _size_.  Should usually be set substantially above
+# flush_largest_memtables_at, since that will have less long-term
+# impact on the system.  
+# 
+# Set to 1.0 to disable.  Setting this lower than
+# CMSInitiatingOccupancyFraction is not likely to be useful.
+reduce_cache_sizes_at: 0.85
+reduce_cache_capacity_to: 0.6
+
+# For workloads with more data than can fit in memory, Cassandra's
+# bottleneck will be reads that need to fetch data from
+# disk. "concurrent_reads" should be set to (16 * number_of_drives) in
+# order to allow the operations to enqueue low enough in the stack
+# that the OS and drives can reorder them.
+#
+# On the other hand, since writes are almost never IO bound, the ideal
+# number of "concurrent_writes" is dependent on the number of cores in
+# your system; (8 * number_of_cores) is a good rule of thumb.
+concurrent_reads: 32
+concurrent_writes: 32
+
+# Total memory to use for memtables.  Cassandra will flush the largest
+# memtable when this much memory is used.
+# If omitted, Cassandra will set it to 1/3 of the heap.
+# memtable_total_space_in_mb: 2048
+
+# Total space to use for commitlogs. 
+# If space gets above this value (it will round up to the next nearest
+# segment multiple), Cassandra will flush every dirty CF in the oldest
+# segment and remove it.
+# commitlog_total_space_in_mb: 4096
 
 # This sets the amount of memtable flush writer threads.  These will
 # be blocked by disk io, and each one will hold a memtable in memory
@@ -104,12 +218,25 @@ concurrent_writes: 4
 # By default this will be set to the amount of data directories defined.
 #memtable_flush_writers: 1
 
-# Buffer size to use when performing contiguous column slices. 
-# Increase this to the size of the column slices you typically perform
-sliced_buffer_size_in_kb: 64
+# the number of full memtables to allow pending flush, that is,
+# waiting for a writer thread.  At a minimum, this should be set to
+# the maximum number of secondary indexes created on a single CF.
+memtable_flush_queue_size: 4
+
+# Whether to, when doing sequential writing, fsync() at intervals in
+# order to force the operating system to flush the dirty
+# buffers. Enable this to avoid sudden dirty buffer flushing from
+# impacting read latencies. Almost always a good idea on SSD:s; not
+# necessarily on platters.
+trickle_fsync: false
+trickle_fsync_interval_in_kb: 10240
 
 # TCP port, for commands and data
 storage_port: 7070
+
+# SSL port, for encrypted communication.  Unused unless enabled in
+# encryption_options
+ssl_storage_port: 7071
 
 # Address to bind to and tell other Cassandra nodes to connect to. You
 # _must_ change this if you want multiple nodes to be able to
@@ -122,6 +249,10 @@ storage_port: 7070
 #
 # Setting this to 0.0.0.0 is always wrong.
 listen_address: 127.0.0.1
+
+# Address to broadcast to other Cassandra nodes
+# Leaving this blank will set it to the same value as listen_address
+# broadcast_address: 1.2.3.4
 
 # The address to bind the Thrift RPC service to -- clients connect
 # here. Unlike ListenAddress above, you *can* specify 0.0.0.0 here if
@@ -136,6 +267,40 @@ rpc_port: 9170
 # enable or disable keepalive on rpc connections
 rpc_keepalive: true
 
+# Cassandra provides three options for the RPC Server:
+#
+# sync  -> One connection per thread in the rpc pool (see below).
+#          For a very large number of clients, memory will be your limiting
+#          factor; on a 64 bit JVM, 128KB is the minimum stack size per thread.
+#          Connection pooling is very, very strongly recommended.
+#
+# async -> Nonblocking server implementation with one thread to serve 
+#          rpc connections.  This is not recommended for high throughput use
+#          cases. Async has been tested to be about 50% slower than sync
+#          or hsha and is deprecated: it will be removed in the next major release.
+#
+# hsha  -> Stands for "half synchronous, half asynchronous." The rpc thread pool 
+#          (see below) is used to manage requests, but the threads are multiplexed
+#          across the different clients.
+#
+# The default is sync because on Windows hsha is about 30% slower.  On Linux,
+# sync/hsha performance is about the same, with hsha of course using less memory.
+rpc_server_type: sync
+
+# Uncomment rpc_min|max|thread to set request pool size.
+# You would primarily set max for the sync server to safeguard against
+# misbehaved clients; if you do hit the max, Cassandra will block until one
+# disconnects before accepting more.  The defaults for sync are min of 16 and max
+# unlimited.
+# 
+# For the Hsha server, the min and max both default to quadruple the number of
+# CPU cores.
+#
+# This configuration is ignored by the async server.
+#
+# rpc_min_threads: 16
+# rpc_max_threads: 2048
+
 # uncomment to set socket buffer sizes on rpc connections
 # rpc_send_buff_size_in_bytes:
 # rpc_recv_buff_size_in_bytes:
@@ -149,15 +314,23 @@ thrift_framed_transport_size_in_mb: 15
 # internal thrift overhead.
 thrift_max_message_length_in_mb: 16
 
+# Set to true to have Cassandra create a hard link to each sstable
+# flushed or streamed locally in a backups/ subdirectory of the
+# Keyspace data.  Removing these links is the operator's
+# responsibility.
+incremental_backups: false
+
 # Whether or not to take a snapshot before each compaction.  Be
 # careful using this option, since Cassandra won't clean up the
 # snapshots for you.  Mostly useful if you're paranoid when there
 # is a data format change.
 snapshot_before_compaction: false
 
-# change this to increase the compaction thread's priority.  In java, 1 is the
-# lowest priority and that is our default.
-# compaction_thread_priority: 1
+# Whether or not a snapshot is taken of the data before keyspace truncation
+# or dropping of column families. The STRONGLY advised default of true 
+# should be used to provide data safety. If you set this flag to false, you will
+# lose data on truncation or drop.
+auto_snapshot: true
 
 # Add column indexes to a row after its contents reach this size.
 # Increase if your column values are large, or if you have a very large
@@ -171,36 +344,110 @@ column_index_size_in_kb: 64
 # Size limit for rows being compacted in memory.  Larger rows will spill
 # over to disk and use a slower two-pass compaction process.  A message
 # will be logged specifying the row key.
-in_memory_compaction_limit_in_mb: 16
+in_memory_compaction_limit_in_mb: 64
+
+# Number of simultaneous compactions to allow, NOT including
+# validation "compactions" for anti-entropy repair.  Simultaneous
+# compactions can help preserve read performance in a mixed read/write
+# workload, by mitigating the tendency of small sstables to accumulate
+# during a single long running compactions. The default is usually
+# fine and if you experience problems with compaction running too
+# slowly or too fast, you should look at
+# compaction_throughput_mb_per_sec first.
+#
+# This setting has no effect on LeveledCompactionStrategy.
+#
+# concurrent_compactors defaults to the number of cores.
+# Uncomment to make compaction mono-threaded, the pre-0.8 default.
+#concurrent_compactors: 1
+
+# Multi-threaded compaction. When enabled, each compaction will use
+# up to one thread per core, plus one thread per sstable being merged.
+# This is usually only useful for SSD-based hardware: otherwise, 
+# your concern is usually to get compaction to do LESS i/o (see:
+# compaction_throughput_mb_per_sec), not more.
+multithreaded_compaction: false
+
+# Throttles compaction to the given total throughput across the entire
+# system. The faster you insert data, the faster you need to compact in
+# order to keep the sstable count down, but in general, setting this to
+# 16 to 32 times the rate you are inserting data is more than sufficient.
+# Setting this to 0 disables throttling. Note that this account for all types
+# of compaction, including validation compaction.
+compaction_throughput_mb_per_sec: 16
+
+# Track cached row keys during compaction, and re-cache their new
+# positions in the compacted sstable.  Disable if you use really large
+# key caches.
+compaction_preheat_key_cache: true
+
+# Throttles all outbound streaming file transfers on this node to the
+# given total throughput in Mbps. This is necessary because Cassandra does
+# mostly sequential IO when streaming data during bootstrap or repair, which
+# can lead to saturating the network connection and degrading rpc performance.
+# When unset, the default is 400 Mbps or 50 MB/s.
+# stream_throughput_outbound_megabits_per_sec: 400
 
 # Time to wait for a reply from other nodes before failing the command 
 rpc_timeout_in_ms: 10000
+
+# Enable socket timeout for streaming operation.
+# When a timeout occurs during streaming, streaming is retried from the start
+# of the current file. This *can* involve re-streaming an important amount of
+# data, so you should avoid setting the value too low.
+# Default value is 0, which never timeout streams.
+# streaming_socket_timeout_in_ms: 0
 
 # phi value that must be reached for a host to be marked down.
 # most users should never need to adjust this.
 # phi_convict_threshold: 8
 
 # endpoint_snitch -- Set this to a class that implements
-# IEndpointSnitch, which will let Cassandra know enough
-# about your network topology to route requests efficiently.
+# IEndpointSnitch.  The snitch has two functions:
+# - it teaches Cassandra enough about your network topology to route
+#   requests efficiently
+# - it allows Cassandra to spread replicas around your cluster to avoid
+#   correlated failures. It does this by grouping machines into
+#   "datacenters" and "racks."  Cassandra will do its best not to have
+#   more than one replica on the same "rack" (which may not actually
+#   be a physical location)
+#
+# IF YOU CHANGE THE SNITCH AFTER DATA IS INSERTED INTO THE CLUSTER,
+# YOU MUST RUN A FULL REPAIR, SINCE THE SNITCH AFFECTS WHERE REPLICAS
+# ARE PLACED.
+#
 # Out of the box, Cassandra provides
-#  - org.apache.cassandra.locator.SimpleSnitch:
+#  - SimpleSnitch:
 #    Treats Strategy order as proximity. This improves cache locality
 #    when disabling read repair, which can further improve throughput.
-#  - org.apache.cassandra.locator.RackInferringSnitch:
+#    Only appropriate for single-datacenter deployments.
+#  - PropertyFileSnitch:
+#    Proximity is determined by rack and data center, which are
+#    explicitly configured in cassandra-topology.properties.
+#  - RackInferringSnitch:
 #    Proximity is determined by rack and data center, which are
 #    assumed to correspond to the 3rd and 2nd octet of each node's
-#    IP address, respectively
-# org.apache.cassandra.locator.PropertyFileSnitch:
-#  - Proximity is determined by rack and data center, which are
-#    explicitly configured in cassandra-rack.properties.
-endpoint_snitch: org.apache.cassandra.locator.SimpleSnitch
+#    IP address, respectively.  Unless this happens to match your
+#    deployment conventions (as it did Facebook's), this is best used
+#    as an example of writing a custom Snitch class.
+#  - Ec2Snitch:
+#    Appropriate for EC2 deployments in a single Region.  Loads Region
+#    and Availability Zone information from the EC2 API. The Region is
+#    treated as the Datacenter, and the Availability Zone as the rack.
+#    Only private IPs are used, so this will not work across multiple
+#    Regions.
+#  - Ec2MultiRegionSnitch:
+#    Uses public IPs as broadcast_address to allow cross-region
+#    connectivity.  (Thus, you should set seed addresses to the public
+#    IP as well.) You will need to open the storage_port or
+#    ssl_storage_port on the public IP firewall.  (For intra-Region
+#    traffic, Cassandra will switch to the private IP after
+#    establishing a connection.)
+#
+# You can use a custom Snitch by setting this to the full class name
+# of the snitch, which will be assumed to be on your classpath.
+endpoint_snitch: SimpleSnitch
 
-# dynamic_snitch -- This boolean controls whether the above snitch is
-# wrapped with a dynamic snitch, which will monitor read latencies
-# and avoid reading from hosts that have slowed (due to compaction,
-# for instance)
-dynamic_snitch: true
 # controls how often to perform the more expensive part of host score
 # calculation
 dynamic_snitch_update_interval_in_ms: 100 
@@ -211,8 +458,10 @@ dynamic_snitch_reset_interval_in_ms: 600000
 # 'pinning' of replicas to hosts in order to increase cache capacity.
 # The badness threshold will control how much worse the pinned host has to be
 # before the dynamic snitch will prefer other replicas over it.  This is
-# expressed as a double which represents a percentage.
-dynamic_snitch_badness_threshold: 0.0
+# expressed as a double which represents a percentage.  Thus, a value of
+# 0.2 means Cassandra would continue to prefer the static snitch values
+# until the pinned host was 20% worse than the fastest.
+dynamic_snitch_badness_threshold: 0.1
 
 # request_scheduler -- Set this to a class that implements
 # RequestScheduler, which will schedule incoming client requests
@@ -227,12 +476,6 @@ dynamic_snitch_badness_threshold: 0.0
 # request_scheduler_options as described below.
 request_scheduler: org.apache.cassandra.scheduler.NoScheduler
 
-encryption_options:
-    internode_encryption: none
-    keystore: conf/.keystore
-    keystore_password: cassandra
-    truststore: conf/.truststore
-    truststore_password: cassandra
 # Scheduler Options vary based on the type of scheduler
 # NoScheduler - Has no options
 # RoundRobin
@@ -260,109 +503,40 @@ encryption_options:
 # the request scheduling. Currently the only valid option is keyspace.
 # request_scheduler_id: keyspace
 
-# The Index Interval determines how large the sampling of row keys
-#  is for a given SSTable. The larger the sampling, the more effective
-#  the index is at the cost of space.
+# index_interval controls the sampling of entries from the primrary
+# row index in terms of space versus time.  The larger the interval,
+# the smaller and less effective the sampling will be.  In technicial
+# terms, the interval coresponds to the number of index entries that
+# are skipped between taking each sample.  All the sampled entries
+# must fit in memory.  Generally, a value between 128 and 512 here
+# coupled with a large key cache size on CFs results in the best trade
+# offs.  This value is not often changed, however if you have many
+# very small rows (many to an OS page), then increasing this will
+# often lower memory usage without a impact on performance.
 index_interval: 128
 
-# A ColumnFamily is the Cassandra concept closest to a relational table. 
+# Enable or disable inter-node encryption
+# Default settings are TLS v1, RSA 1024-bit keys (it is imperative that
+# users generate their own keys) TLS_RSA_WITH_AES_128_CBC_SHA as the cipher
+# suite for authentication, key exchange and encryption of the actual data transfers.
+# NOTE: No custom encryption options are enabled at the moment
+# The available internode options are : all, none, dc, rack
 #
-# Keyspaces are separate groups of ColumnFamilies.  Except in very
-# unusual circumstances you will have one Keyspace per application.
+# If set to dc cassandra will encrypt the traffic between the DCs
+# If set to rack cassandra will encrypt the traffic between the racks
 #
-# Keyspace required parameters:
-# - name: name of the keyspace; "system" and "definitions" are 
-#   reserved for Cassandra Internals.
-# - replica_placement_strategy: the class that determines how replicas
-#   are distributed among nodes. Contains both the class as well as
-#   configuration information.  Must extend AbstractReplicationStrategy.
-#   Out of the box, Cassandra provides 
-#     * org.apache.cassandra.locator.SimpleStrategy 
-#     * org.apache.cassandra.locator.NetworkTopologyStrategy
-#     * org.apache.cassandra.locator.OldNetworkTopologyStrategy
+# The passwords used in these options must match the passwords used when generating
+# the keystore and truststore.  For instructions on generating these files, see:
+# http://download.oracle.com/javase/6/docs/technotes/guides/security/jsse/JSSERefGuide.html#CreateKeystore
 #
-#   SimpleStrategy merely places the first
-#   replica at the node whose token is closest to the key (as determined
-#   by the Partitioner), and additional replicas on subsequent nodes
-#   along the ring in increasing Token order.
-# 
-#   With NetworkTopologyStrategy,
-#   for each datacenter, you can specify how many replicas you want
-#   on a per-keyspace basis.  Replicas are placed on different racks
-#   within each DC, if possible. This strategy also requires rack aware
-#   snitch, such as RackInferringSnitch or PropertyFileSnitch.
-#   An example:
-#    - name: Keyspace1
-#      replica_placement_strategy: org.apache.cassandra.locator.NetworkTopologyStrategy
-#      strategy_options:
-#        DC1 : 3
-#        DC2 : 2
-#        DC3 : 1
-# 
-#   OldNetworkToplogyStrategy [formerly RackAwareStrategy] 
-#   places one replica in each of two datacenters, and the third on a
-#   different rack in in the first.  Additional datacenters are not
-#   guaranteed to get a replica.  Additional replicas after three are placed
-#   in ring order after the third without regard to rack or datacenter.
-#
-# - replication_factor: Number of replicas of each row
-# - column_families: column families associated with this keyspace
-#
-#     ColumnFamily required parameters:
-#     - name: name of the ColumnFamily.  Must not contain the character "-".
-#     - compare_with: tells Cassandra how to sort the columns for slicing
-#       operations. The default is BytesType, which is a straightforward
-#       lexical comparison of the bytes in each column.  Other options are
-#       AsciiType, UTF8Type, LexicalUUIDType, TimeUUIDType, LongType,
-#       and IntegerType (a generic variable-length integer type).
-#       You can also specify the fully-qualified class name to a class of
-#       your choice extending org.apache.cassandra.db.marshal.AbstractType.
-#    
-#     ColumnFamily optional parameters:
-#     - keys_cached: specifies the number of keys per sstable whose
-#        locations we keep in memory in "mostly LRU" order.  (JUST the key
-#        locations, NOT any column values.) Specify a fraction (value less
-#        than 1) or an absolute number of keys to cache.  Defaults to 200000
-#        keys.
-#     - rows_cached: specifies the number of rows whose entire contents we
-#        cache in memory. Do not use this on ColumnFamilies with large rows,
-#        or ColumnFamilies with high write:read ratios. Specify a fraction
-#        (value less than 1) or an absolute number of rows to cache.
-#        Defaults to 0. (i.e. row caching is off by default)
-#     - comment: used to attach additional human-readable information about 
-#        the column family to its definition.
-#     - read_repair_chance: specifies the probability with which read
-#        repairs should be invoked on non-quorum reads.  must be between 0
-#        and 1. defaults to 1.0 (always read repair).
-#     - gc_grace_seconds: specifies the time to wait before garbage
-#        collecting tombstones (deletion markers). defaults to 864000 (10
-#        days). See http://wiki.apache.org/cassandra/DistributedDeletes
-#     - default_validation_class: specifies a validator class to use for
-#        validating all the column values in the CF.
-#     - min_compaction_threshold: the minimum number of SSTables needed
-#        to start a minor compaction.  increasing this will cause minor
-#        compactions to start less frequently and be more intensive. setting
-#        this to 0 disables minor compactions.  defaults to 4.
-#     - max_compaction_threshold: the maximum number of SSTables allowed
-#        before a minor compaction is forced.  decreasing this will cause
-#        minor compactions to start more frequently and be less intensive.
-#        setting this to 0 disables minor compactions.  defaults to 32.
-#     - row_cache_save_period_in_seconds: number of seconds between saving
-#        row caches.  The row caches can be saved periodically and if one
-#        exists on startup it will be loaded.
-#     - key_cache_save_period_in_seconds: number of seconds between saving
-#        key caches.  The key caches can be saved periodically and if one 
-#        exists on startup it will be loaded.
-#     - memtable_flush_after_mins: The maximum time to leave a dirty table
-#        unflushed.  This should be large enough that it won't cause a flush
-#        storm of all memtables during periods of inactivity.
-#     - memtable_throughput_in_mb: The maximum size of the memtable before
-#        it is flushed.  If undefined, 1/8 * heapsize will be used.
-#     - memtable_operations_in_millions: Number of operations in millions
-#        before the memtable is flushed. If undefined, throughput / 64 * 0.3
-#        will be used.
-#
-# NOTE: this keyspace definition is for demonstration purposes only.
-#       Cassandra will not load these definitions during startup. See
-#       http://wiki.apache.org/cassandra/FAQ#no_keyspaces for an explanation.
-  
+encryption_options:
+    internode_encryption: none
+    keystore: conf/.keystore
+    keystore_password: cassandra
+    truststore: conf/.truststore
+    truststore_password: cassandra
+    # More advanced defaults below:
+    # protocol: TLS
+    # algorithm: SunX509
+    # store_type: JKS
+    # cipher_suites: [TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA]

--- a/object-mapper/pom.xml
+++ b/object-mapper/pom.xml
@@ -31,6 +31,22 @@
 	</build>
 
 	<dependencies>
+
+                <!--for abstract types? -->
+                <dependency>
+                        <groupId>org.apache.cassandra</groupId>
+                        <artifactId>cassandra-all</artifactId>
+                </dependency>
+
+
+                <!-- for junit -->
+                <dependency>
+                        <groupId>junit</groupId>
+                        <artifactId>junit</artifactId>
+                        <scope>test</scope>
+                </dependency>
+
+
 		<dependency>
 			<groupId>me.prettyprint</groupId>
 			<artifactId>hector-core</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
       <dependency>
         <groupId>org.apache.cassandra</groupId>
         <artifactId>cassandra-all</artifactId>
-        <version>1.0.9</version>
+        <version>1.1.0</version>
         <exclusions>
           <exclusion>
 	    <groupId>com.github.stephenc</groupId>
@@ -100,7 +100,7 @@
       <dependency>
         <groupId>org.apache.cassandra</groupId>
         <artifactId>cassandra-thrift</artifactId>
-        <version>1.0.9</version>
+        <version>1.1.0</version>
       </dependency>
       <dependency>
         <groupId>commons-lang</groupId>

--- a/test/src/main/java/me/prettyprint/hector/testutils/EmbeddedSchemaLoader.java
+++ b/test/src/main/java/me/prettyprint/hector/testutils/EmbeddedSchemaLoader.java
@@ -33,7 +33,7 @@ public class EmbeddedSchemaLoader {
   public static void loadSchema() {
     try
     {
-      Schema.instance.load(schemaDefinition(), Schema.instance.getVersion());
+      Schema.instance.load(schemaDefinition());
     }
     catch (ConfigurationException e)
     {
@@ -79,7 +79,7 @@ public class EmbeddedSchemaLoader {
         superCFMD(ks1, "Super5", bytes),
         indexCFMD(ks1, "Indexed1", true),
         indexCFMD(ks1, "Indexed2", false),
-        new CFMetaData(ks1, "StandardInteger1", st, IntegerType.instance, null).keyCacheSize(0),        
+        //new CFMetaData(ks1, "StandardInteger1", st, IntegerType.instance, null).keyCacheSize(0),
         new CFMetaData(ks1, "Counter1", st, bytes, null).replicateOnWrite(true).defaultValidator(CounterColumnType.instance),
         new CFMetaData(ks1, "Counter2", st, bytes, null).replicateOnWrite(true).defaultValidator(CounterColumnType.instance),
         new CFMetaData(ks1, "SuperCounter1", su, bytes, bytes).replicateOnWrite(true).defaultValidator(CounterColumnType.instance),
@@ -94,24 +94,19 @@ public class EmbeddedSchemaLoader {
     return schema;
   }
 
-  private static CFMetaData compositeCFMD(String ksName, String cfName, AbstractType... types) {
-    try {
+  private static CFMetaData compositeCFMD(String ksName, String cfName, AbstractType<?>... types) {
       return new CFMetaData(ksName, cfName, ColumnFamilyType.Standard, CompositeType.getInstance(Arrays.asList(types)), null);      
-    } catch (ConfigurationException e) {
-      
-    }
-    return null;
   }
   
   private static CFMetaData standardCFMD(String ksName, String cfName) {
     return new CFMetaData(ksName, cfName, ColumnFamilyType.Standard,
-        BytesType.instance, null).keyCacheSize(0);
+        BytesType.instance, null);
   }
 
   private static CFMetaData superCFMD(String ksName, String cfName,
       AbstractType subcc) {
     return new CFMetaData(ksName, cfName, ColumnFamilyType.Super,
-        BytesType.instance, subcc).keyCacheSize(0);
+        BytesType.instance, subcc);
   }
 
   private static CFMetaData indexCFMD(String ksName, String cfName, final Boolean withIdxType)
@@ -122,7 +117,9 @@ public class EmbeddedSchemaLoader {
                   {{
                       ByteBuffer cName = ByteBuffer.wrap("birthyear".getBytes(Charsets.UTF_8));
                       IndexType keys = withIdxType ? IndexType.KEYS : null;
-                      put(cName, new ColumnDefinition(cName, LongType.instance, keys, null, "birthyear_index"));
+                      //TODO: that last null is for composites. Need to understand that better, but null is reasonable
+                      ColumnDefinition def = new org.apache.cassandra.config.ColumnDefinition(cName,LongType.instance,IndexType.KEYS,null,"birthyear_index",null);
+                      put (cName,def);
                   }});
   }
 
@@ -140,7 +137,7 @@ public class EmbeddedSchemaLoader {
         .keyValidator(UTF8Type.instance).columnMetadata(new HashMap<ByteBuffer, ColumnDefinition>()
             {{
               ByteBuffer cName = ByteBuffer.wrap("birthyear".getBytes(Charsets.UTF_8));
-              put(cName, new ColumnDefinition(cName, LongType.instance, null, null, null));
+              put(cName, new ColumnDefinition(cName, LongType.instance, null, null, null,null));
           }});
   }
 }


### PR DESCRIPTION
[edward@tablitha hector]$ grep ERROR /home/edward/hect-ed/hector/core/target/surefire-reports/*/home/edward/hect-ed/hector/core/target/surefire-reports/me.prettyprint.hector.api.ApiV2SystemTest.txt:testRangeSuperSlicesQuery(me.prettyprint.hector.api.ApiV2SystemTest)  Time elapsed: 0.017 sec  <<< ERROR!
/home/edward/hect-ed/hector/core/target/surefire-reports/me.prettyprint.hector.api.ApiV2SystemTest.txt:testRangeSuperSlicesQuery_order(me.prettyprint.hector.api.ApiV2SystemTest)  Time elapsed: 0.017 sec  <<< ERROR!
/home/edward/hect-ed/hector/core/target/surefire-reports/me.prettyprint.hector.api.VirtualKeyspaceTest.txt:testRangeSuperSlicesQuery(me.prettyprint.hector.api.VirtualKeyspaceTest)  Time elapsed: 0.018 sec  <<< ERROR!
/home/edward/hect-ed/hector/core/target/surefire-reports/me.prettyprint.hector.api.VirtualKeyspaceTest.txt:testRangeSuperSlicesQuery_order(me.prettyprint.hector.api.VirtualKeyspaceTest)  Time elapsed: 0.019 sec  <<< ERROR!
/home/edward/hect-ed/hector/core/target/surefire-reports/me.prettyprint.hector.api.VirtualKeyspaceTest.txt:testRangeSubSlicesQuery(me.prettyprint.hector.api.VirtualKeyspaceTest)  Time elapsed: 0.017 sec  <<< ERROR!
/home/edward/hect-ed/hector/core/target/surefire-reports/TEST-me.prettyprint.hector.api.VirtualKeyspaceTest.xml:    <system-out>13:05:16,164 ERROR PrefixedSerializer:66 - Unprefixed value received, throwing exception...
/home/edward/hect-ed/hector/core/target/surefire-reports/TEST-me.prettyprint.hector.api.VirtualKeyspaceTest.xml:13:05:16,164 ERROR PrefixedSerializer:66 - Unprefixed value received, throwing exception...
/home/edward/hect-ed/hector/core/target/surefire-reports/TEST-me.prettyprint.hector.api.VirtualKeyspaceTest.xml:13:05:16,165 ERROR PrefixedSerializer:66 - Unprefixed value received, throwing exception...
/home/edward/hect-ed/hector/core/target/surefire-reports/TEST-me.prettyprint.hector.api.VirtualKeyspaceTest.xml:    <system-out>13:05:16,256 ERROR PrefixedSerializer:66 - Unprefixed value received, throwing exception...
[edward@tablitha hector]$ 
