### PR TITLE
Handle custom index types.

### DIFF
--- a/core/src/main/java/me/prettyprint/cassandra/service/ThriftColumnDef.java
+++ b/core/src/main/java/me/prettyprint/cassandra/service/ThriftColumnDef.java
@@ -106,7 +106,7 @@ public class ThriftColumnDef implements ColumnDefinition {
     case KEYS:
       return IndexType.KEYS;
     case CUSTOM:
-      return ColumnIndexType.CUSTOM;
+      return IndexType.CUSTOM;
     default:
       throw new RuntimeException("Unknown ColumnIndexType value: " + indexType2);
     }


### PR DESCRIPTION
It looks like we updated  the 'indexTypeFromThrift' method without also updating the corresponding 'indexTypeToThrift' method. This just fixes that.
