### PR TITLE
better load balancing algorithm

### DIFF
--- a/core/src/main/java/me/prettyprint/cassandra/connection/DynamicLoadBalancingPolicy.java
+++ b/core/src/main/java/me/prettyprint/cassandra/connection/DynamicLoadBalancingPolicy.java
@@ -77,13 +77,12 @@ public class DynamicLoadBalancingPolicy implements LoadBalancingPolicy {
       HClientPool np = poolList.get(i);
       Double next = scores.get(np);
       if ((first - next) / first > DYNAMIC_BADNESS_THRESHOLD) {
-        Collections.sort(poolList, new SortByScoreComparator());
-        if (log.isDebugEnabled())
-          log.debug(String.format("According to score we have chosen {} vs first {}", poolList.get(0), fp));
-        break;
+        // This server is better by a big enough margin that we should pick it instead.
+        first = next;
+        fp = np;
       }
     }
-    return poolList.get(0);
+    return fp;
   }
 
   private void filter(List<HClientPool> from, Set<CassandraHost> subList) {


### PR DESCRIPTION
The current algorithm will switch to always returning just the best server
when even only one server is behaving badly. This will force all of the load
onto one machine.

This new algorithm still starts by picking a random machine, but will instead
switch to the next random machine in the list that has a better score.
