### PR TITLE
More iterators for other slice queries types

### DIFF
--- a/core/src/main/java/me/prettyprint/cassandra/service/MultigetSuperSliceCounterIterator.java
+++ b/core/src/main/java/me/prettyprint/cassandra/service/MultigetSuperSliceCounterIterator.java
@@ -2,24 +2,26 @@ package me.prettyprint.cassandra.service;
 
 import java.util.Iterator;
 import java.util.List;
-import me.prettyprint.hector.api.beans.HColumn;
-import me.prettyprint.hector.api.query.SliceQuery;
+
+import me.prettyprint.hector.api.beans.HCounterSuperColumn;
+import me.prettyprint.hector.api.query.MultigetSuperSliceCounterQuery;
 
 /**
- * Iterates over the column slice, refreshing until all qualifing columns are
+ * Iterates over the super-column slice, refreshing until all qualifing columns are
  * retrieved.
- * If column deletion can occur synchronously with calls to {@link #hasNext hasNext()},
- * the column name object type must override Object.equals().
+ * If super-column deletion can occur synchronously with calls to {@link #hasNext hasNext()},
+ * the super-column name object type must override Object.equals().
  *
  * @author thrykol
+ * @author pescuma
  */
-public class ColumnSliceIterator<K, N, V> implements Iterator<HColumn<N, V>> {
+public class MultigetSuperSliceCounterIterator<K, SN, N> implements Iterator<HCounterSuperColumn<SN, N>> {
 
 	private static final int DEFAULT_COUNT = 100;
-	private SliceQuery<K, N, V> query;
-	private Iterator<HColumn<N, V>> iterator;
-	private N start;
-	private ColumnSliceFinish<N> finish;
+	private MultigetSuperSliceCounterQuery<K, SN, N> query;
+	private Iterator<HCounterSuperColumn<SN, N>> iterator;
+	private SN start;
+	private ColumnSliceFinish<SN> finish;
 	private boolean reversed;
 	private int count = DEFAULT_COUNT;
 	private int columns = 0;
@@ -32,7 +34,7 @@ public class ColumnSliceIterator<K, N, V> implements Iterator<HColumn<N, V>> {
 	 * @param finish Finish point of the range.
 	 * @param reversed Whether or not the columns should be reversed
 	 */
-	public ColumnSliceIterator(SliceQuery<K, N, V> query, N start, final N finish, boolean reversed) {
+	public MultigetSuperSliceCounterIterator(MultigetSuperSliceCounterQuery<K, SN, N> query, SN start, final SN finish, boolean reversed) {
 		this(query, start, finish, reversed, DEFAULT_COUNT);
 	}
 
@@ -45,11 +47,11 @@ public class ColumnSliceIterator<K, N, V> implements Iterator<HColumn<N, V>> {
 	 * @param reversed Whether or not the columns should be reversed
 	 * @param count the amount of columns to retrieve per batch
 	 */
-	public ColumnSliceIterator(SliceQuery<K, N, V> query, N start, final N finish, boolean reversed, int count) {
-		this(query, start, new ColumnSliceFinish<N>() {
+	public MultigetSuperSliceCounterIterator(MultigetSuperSliceCounterQuery<K, SN, N> query, SN start, final SN finish, boolean reversed, int count) {
+		this(query, start, new ColumnSliceFinish<SN>() {
 
 			@Override
-			public N function() {
+			public SN function() {
 				return finish;
 			}
 		}, reversed, count);
@@ -64,7 +66,7 @@ public class ColumnSliceIterator<K, N, V> implements Iterator<HColumn<N, V>> {
 	 * determined point
 	 * @param reversed Whether or not the columns should be reversed
 	 */
-	public ColumnSliceIterator(SliceQuery<K, N, V> query, N start, ColumnSliceFinish<N> finish, boolean reversed) {
+	public MultigetSuperSliceCounterIterator(MultigetSuperSliceCounterQuery<K, SN, N> query, SN start, ColumnSliceFinish<SN> finish, boolean reversed) {
 		this(query, start, finish, reversed, DEFAULT_COUNT);
 	}
 
@@ -78,7 +80,7 @@ public class ColumnSliceIterator<K, N, V> implements Iterator<HColumn<N, V>> {
 	 * @param reversed Whether or not the columns should be reversed
 	 * @param count the amount of columns to retrieve per batch
 	 */
-	public ColumnSliceIterator(SliceQuery<K, N, V> query, N start, ColumnSliceFinish<N> finish, boolean reversed, int count) {
+	public MultigetSuperSliceCounterIterator(MultigetSuperSliceCounterQuery<K, SN, N> query, SN start, ColumnSliceFinish<SN> finish, boolean reversed, int count) {
 		this.query = query;
 		this.start = start;
 		this.finish = finish;
@@ -90,18 +92,18 @@ public class ColumnSliceIterator<K, N, V> implements Iterator<HColumn<N, V>> {
 	@Override
 	public boolean hasNext() {
 		if (iterator == null) {
-			iterator = query.execute().get().getColumns().iterator();
+			iterator = query.execute().get().iterator().next().getSuperSlice().getSuperColumns().iterator();
 		} else if (!iterator.hasNext() && columns == count) {  // only need to do another query if maximum columns were retrieved
 			query.setRange(start, finish.function(), reversed, count);
 			columns = 0;
-			List<HColumn<N, V>> list = query.execute().get().getColumns();
+			List<HCounterSuperColumn<SN, N>> list = query.execute().get().iterator().next().getSuperSlice().getSuperColumns();
 			iterator = list.iterator();
 
 			if (iterator.hasNext()) {
 				// The lower bound column may have been removed prior to the query executing,
 				// so check to see if the first column returned by the current query is the same
 				// as the lower bound column.  If both columns are the same, skip the column
-				N first = list.get(0).getName();
+				SN first = list.get(0).getName();
 				if (first.equals(start)) {
 					iterator.next();
 				}
@@ -112,8 +114,8 @@ public class ColumnSliceIterator<K, N, V> implements Iterator<HColumn<N, V>> {
 	}
 
 	@Override
-	public HColumn<N, V> next() {
-		HColumn<N, V> column = iterator.next();
+	public HCounterSuperColumn<SN, N> next() {
+		HCounterSuperColumn<SN, N> column = iterator.next();
 		start = column.getName();
 		columns++;
 

--- a/core/src/main/java/me/prettyprint/cassandra/service/SliceCounterIterator.java
+++ b/core/src/main/java/me/prettyprint/cassandra/service/SliceCounterIterator.java
@@ -2,8 +2,9 @@ package me.prettyprint.cassandra.service;
 
 import java.util.Iterator;
 import java.util.List;
-import me.prettyprint.hector.api.beans.HColumn;
-import me.prettyprint.hector.api.query.SliceQuery;
+
+import me.prettyprint.hector.api.beans.HCounterColumn;
+import me.prettyprint.hector.api.query.SliceCounterQuery;
 
 /**
  * Iterates over the column slice, refreshing until all qualifing columns are
@@ -12,12 +13,13 @@ import me.prettyprint.hector.api.query.SliceQuery;
  * the column name object type must override Object.equals().
  *
  * @author thrykol
+ * @author pescuma
  */
-public class ColumnSliceIterator<K, N, V> implements Iterator<HColumn<N, V>> {
+public class SliceCounterIterator<K, N> implements Iterator<HCounterColumn<N>> {
 
 	private static final int DEFAULT_COUNT = 100;
-	private SliceQuery<K, N, V> query;
-	private Iterator<HColumn<N, V>> iterator;
+	private SliceCounterQuery<K, N> query;
+	private Iterator<HCounterColumn<N>> iterator;
 	private N start;
 	private ColumnSliceFinish<N> finish;
 	private boolean reversed;
@@ -32,7 +34,7 @@ public class ColumnSliceIterator<K, N, V> implements Iterator<HColumn<N, V>> {
 	 * @param finish Finish point of the range.
 	 * @param reversed Whether or not the columns should be reversed
 	 */
-	public ColumnSliceIterator(SliceQuery<K, N, V> query, N start, final N finish, boolean reversed) {
+	public SliceCounterIterator(SliceCounterQuery<K, N> query, N start, final N finish, boolean reversed) {
 		this(query, start, finish, reversed, DEFAULT_COUNT);
 	}
 
@@ -45,7 +47,7 @@ public class ColumnSliceIterator<K, N, V> implements Iterator<HColumn<N, V>> {
 	 * @param reversed Whether or not the columns should be reversed
 	 * @param count the amount of columns to retrieve per batch
 	 */
-	public ColumnSliceIterator(SliceQuery<K, N, V> query, N start, final N finish, boolean reversed, int count) {
+	public SliceCounterIterator(SliceCounterQuery<K, N> query, N start, final N finish, boolean reversed, int count) {
 		this(query, start, new ColumnSliceFinish<N>() {
 
 			@Override
@@ -64,7 +66,7 @@ public class ColumnSliceIterator<K, N, V> implements Iterator<HColumn<N, V>> {
 	 * determined point
 	 * @param reversed Whether or not the columns should be reversed
 	 */
-	public ColumnSliceIterator(SliceQuery<K, N, V> query, N start, ColumnSliceFinish<N> finish, boolean reversed) {
+	public SliceCounterIterator(SliceCounterQuery<K, N> query, N start, ColumnSliceFinish<N> finish, boolean reversed) {
 		this(query, start, finish, reversed, DEFAULT_COUNT);
 	}
 
@@ -78,7 +80,7 @@ public class ColumnSliceIterator<K, N, V> implements Iterator<HColumn<N, V>> {
 	 * @param reversed Whether or not the columns should be reversed
 	 * @param count the amount of columns to retrieve per batch
 	 */
-	public ColumnSliceIterator(SliceQuery<K, N, V> query, N start, ColumnSliceFinish<N> finish, boolean reversed, int count) {
+	public SliceCounterIterator(SliceCounterQuery<K, N> query, N start, ColumnSliceFinish<N> finish, boolean reversed, int count) {
 		this.query = query;
 		this.start = start;
 		this.finish = finish;
@@ -94,7 +96,7 @@ public class ColumnSliceIterator<K, N, V> implements Iterator<HColumn<N, V>> {
 		} else if (!iterator.hasNext() && columns == count) {  // only need to do another query if maximum columns were retrieved
 			query.setRange(start, finish.function(), reversed, count);
 			columns = 0;
-			List<HColumn<N, V>> list = query.execute().get().getColumns();
+			List<HCounterColumn<N>> list = query.execute().get().getColumns();
 			iterator = list.iterator();
 
 			if (iterator.hasNext()) {
@@ -112,8 +114,8 @@ public class ColumnSliceIterator<K, N, V> implements Iterator<HColumn<N, V>> {
 	}
 
 	@Override
-	public HColumn<N, V> next() {
-		HColumn<N, V> column = iterator.next();
+	public HCounterColumn<N> next() {
+		HCounterColumn<N> column = iterator.next();
 		start = column.getName();
 		columns++;
 

--- a/core/src/main/java/me/prettyprint/cassandra/service/SubSliceCounterIterator.java
+++ b/core/src/main/java/me/prettyprint/cassandra/service/SubSliceCounterIterator.java
@@ -2,22 +2,24 @@ package me.prettyprint.cassandra.service;
 
 import java.util.Iterator;
 import java.util.List;
-import me.prettyprint.hector.api.beans.HColumn;
-import me.prettyprint.hector.api.query.SliceQuery;
+
+import me.prettyprint.hector.api.beans.HCounterColumn;
+import me.prettyprint.hector.api.query.SubSliceCounterQuery;
 
 /**
- * Iterates over the column slice, refreshing until all qualifing columns are
+ * Iterates over the sub-column slice, refreshing until all qualifing columns are
  * retrieved.
- * If column deletion can occur synchronously with calls to {@link #hasNext hasNext()},
- * the column name object type must override Object.equals().
+ * If sub-column deletion can occur synchronously with calls to {@link #hasNext hasNext()},
+ * the sub-column name object type must override Object.equals().
  *
  * @author thrykol
+ * @author pescuma
  */
-public class ColumnSliceIterator<K, N, V> implements Iterator<HColumn<N, V>> {
+public class SubSliceCounterIterator<K, SN, N> implements Iterator<HCounterColumn<N>> {
 
 	private static final int DEFAULT_COUNT = 100;
-	private SliceQuery<K, N, V> query;
-	private Iterator<HColumn<N, V>> iterator;
+	private SubSliceCounterQuery<K, SN, N> query;
+	private Iterator<HCounterColumn<N>> iterator;
 	private N start;
 	private ColumnSliceFinish<N> finish;
 	private boolean reversed;
@@ -32,7 +34,7 @@ public class ColumnSliceIterator<K, N, V> implements Iterator<HColumn<N, V>> {
 	 * @param finish Finish point of the range.
 	 * @param reversed Whether or not the columns should be reversed
 	 */
-	public ColumnSliceIterator(SliceQuery<K, N, V> query, N start, final N finish, boolean reversed) {
+	public SubSliceCounterIterator(SubSliceCounterQuery<K, SN, N> query, N start, final N finish, boolean reversed) {
 		this(query, start, finish, reversed, DEFAULT_COUNT);
 	}
 
@@ -45,7 +47,7 @@ public class ColumnSliceIterator<K, N, V> implements Iterator<HColumn<N, V>> {
 	 * @param reversed Whether or not the columns should be reversed
 	 * @param count the amount of columns to retrieve per batch
 	 */
-	public ColumnSliceIterator(SliceQuery<K, N, V> query, N start, final N finish, boolean reversed, int count) {
+	public SubSliceCounterIterator(SubSliceCounterQuery<K, SN, N> query, N start, final N finish, boolean reversed, int count) {
 		this(query, start, new ColumnSliceFinish<N>() {
 
 			@Override
@@ -64,7 +66,7 @@ public class ColumnSliceIterator<K, N, V> implements Iterator<HColumn<N, V>> {
 	 * determined point
 	 * @param reversed Whether or not the columns should be reversed
 	 */
-	public ColumnSliceIterator(SliceQuery<K, N, V> query, N start, ColumnSliceFinish<N> finish, boolean reversed) {
+	public SubSliceCounterIterator(SubSliceCounterQuery<K, SN, N> query, N start, ColumnSliceFinish<N> finish, boolean reversed) {
 		this(query, start, finish, reversed, DEFAULT_COUNT);
 	}
 
@@ -78,7 +80,7 @@ public class ColumnSliceIterator<K, N, V> implements Iterator<HColumn<N, V>> {
 	 * @param reversed Whether or not the columns should be reversed
 	 * @param count the amount of columns to retrieve per batch
 	 */
-	public ColumnSliceIterator(SliceQuery<K, N, V> query, N start, ColumnSliceFinish<N> finish, boolean reversed, int count) {
+	public SubSliceCounterIterator(SubSliceCounterQuery<K, SN, N> query, N start, ColumnSliceFinish<N> finish, boolean reversed, int count) {
 		this.query = query;
 		this.start = start;
 		this.finish = finish;
@@ -94,7 +96,7 @@ public class ColumnSliceIterator<K, N, V> implements Iterator<HColumn<N, V>> {
 		} else if (!iterator.hasNext() && columns == count) {  // only need to do another query if maximum columns were retrieved
 			query.setRange(start, finish.function(), reversed, count);
 			columns = 0;
-			List<HColumn<N, V>> list = query.execute().get().getColumns();
+			List<HCounterColumn<N>> list = query.execute().get().getColumns();
 			iterator = list.iterator();
 
 			if (iterator.hasNext()) {
@@ -112,8 +114,8 @@ public class ColumnSliceIterator<K, N, V> implements Iterator<HColumn<N, V>> {
 	}
 
 	@Override
-	public HColumn<N, V> next() {
-		HColumn<N, V> column = iterator.next();
+	public HCounterColumn<N> next() {
+		HCounterColumn<N> column = iterator.next();
 		start = column.getName();
 		columns++;
 

--- a/core/src/main/java/me/prettyprint/cassandra/service/SubSliceIterator.java
+++ b/core/src/main/java/me/prettyprint/cassandra/service/SubSliceIterator.java
@@ -2,21 +2,23 @@ package me.prettyprint.cassandra.service;
 
 import java.util.Iterator;
 import java.util.List;
+
 import me.prettyprint.hector.api.beans.HColumn;
-import me.prettyprint.hector.api.query.SliceQuery;
+import me.prettyprint.hector.api.query.SubSliceQuery;
 
 /**
- * Iterates over the column slice, refreshing until all qualifing columns are
+ * Iterates over the sub-column slice, refreshing until all qualifing columns are
  * retrieved.
- * If column deletion can occur synchronously with calls to {@link #hasNext hasNext()},
- * the column name object type must override Object.equals().
+ * If sub-column deletion can occur synchronously with calls to {@link #hasNext hasNext()},
+ * the sub-column name object type must override Object.equals().
  *
  * @author thrykol
+ * @author pescuma
  */
-public class ColumnSliceIterator<K, N, V> implements Iterator<HColumn<N, V>> {
+public class SubSliceIterator<K, SN, N, V> implements Iterator<HColumn<N, V>> {
 
 	private static final int DEFAULT_COUNT = 100;
-	private SliceQuery<K, N, V> query;
+	private SubSliceQuery<K, SN, N, V> query;
 	private Iterator<HColumn<N, V>> iterator;
 	private N start;
 	private ColumnSliceFinish<N> finish;
@@ -32,7 +34,7 @@ public class ColumnSliceIterator<K, N, V> implements Iterator<HColumn<N, V>> {
 	 * @param finish Finish point of the range.
 	 * @param reversed Whether or not the columns should be reversed
 	 */
-	public ColumnSliceIterator(SliceQuery<K, N, V> query, N start, final N finish, boolean reversed) {
+	public SubSliceIterator(SubSliceQuery<K, SN, N, V> query, N start, final N finish, boolean reversed) {
 		this(query, start, finish, reversed, DEFAULT_COUNT);
 	}
 
@@ -45,7 +47,7 @@ public class ColumnSliceIterator<K, N, V> implements Iterator<HColumn<N, V>> {
 	 * @param reversed Whether or not the columns should be reversed
 	 * @param count the amount of columns to retrieve per batch
 	 */
-	public ColumnSliceIterator(SliceQuery<K, N, V> query, N start, final N finish, boolean reversed, int count) {
+	public SubSliceIterator(SubSliceQuery<K, SN, N, V> query, N start, final N finish, boolean reversed, int count) {
 		this(query, start, new ColumnSliceFinish<N>() {
 
 			@Override
@@ -64,7 +66,7 @@ public class ColumnSliceIterator<K, N, V> implements Iterator<HColumn<N, V>> {
 	 * determined point
 	 * @param reversed Whether or not the columns should be reversed
 	 */
-	public ColumnSliceIterator(SliceQuery<K, N, V> query, N start, ColumnSliceFinish<N> finish, boolean reversed) {
+	public SubSliceIterator(SubSliceQuery<K, SN, N, V> query, N start, ColumnSliceFinish<N> finish, boolean reversed) {
 		this(query, start, finish, reversed, DEFAULT_COUNT);
 	}
 
@@ -78,7 +80,7 @@ public class ColumnSliceIterator<K, N, V> implements Iterator<HColumn<N, V>> {
 	 * @param reversed Whether or not the columns should be reversed
 	 * @param count the amount of columns to retrieve per batch
 	 */
-	public ColumnSliceIterator(SliceQuery<K, N, V> query, N start, ColumnSliceFinish<N> finish, boolean reversed, int count) {
+	public SubSliceIterator(SubSliceQuery<K, SN, N, V> query, N start, ColumnSliceFinish<N> finish, boolean reversed, int count) {
 		this.query = query;
 		this.start = start;
 		this.finish = finish;


### PR DESCRIPTION
There are iterators for slice queries of counter columns, sub-columns and super-columns. 

The pattern for naming the classes is: replace Query at the end of the classname with Iterator, so there are:
- SliceCounterQuery -> SliceCounterIterator
- SubSliceQuery -> SubSliceIterator
- SubSliceCounterQuery -> SubSliceCounterIterator
- SuperSliceQuery -> SuperSliceIterator
- MultigetSuperSliceCounterQuery -> MultigetSuperSliceCounterIterator

To keep the pattern I think ColumnSliceIterator should be named SliceIterator, but I didn't rename it to avoid compilation errors in clients.
