### PR TITLE
hector core shouldn't depend on cassandra-all

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -101,9 +101,6 @@
       <groupId>commons-pool</groupId>
       <artifactId>commons-pool</artifactId>
     </dependency>
-
-   <!--for abstract types? -->
-
     <dependency>
       <groupId>org.apache.cassandra</groupId>
       <artifactId>cassandra-thrift</artifactId>


### PR DESCRIPTION
if hector core depends on cassandra-all, a project depending on hector-core brings in the following as transitive dependencies,

[INFO] |  +- org.xerial.snappy:snappy-java:jar:1.0.4.1:compile
[INFO] |  +- com.ning:compress-lzf:jar:0.8.4:compile
[INFO] |  +- com.google.guava:guava:jar:r09:compile (version managed from r08)
[INFO] |  +- commons-cli:commons-cli:jar:1.1:compile
[INFO] |  +- commons-codec:commons-codec:jar:1.2:compile
[INFO] |  +- commons-lang:commons-lang:jar:2.4:compile
[INFO] |  +- com.googlecode.concurrentlinkedhashmap:concurrentlinkedhashmap-lru:jar:1.2:compile
[INFO] |  +- org.antlr:antlr:jar:3.2:compile
[INFO] |  |  - org.antlr:antlr-runtime:jar:3.2:compile
[INFO] |  |     - org.antlr:stringtemplate:jar:3.2:compile
[INFO] |  |        - antlr:antlr:jar:2.7.7:compile
[INFO] |  +- org.slf4j:slf4j-api:jar:1.6.1:compile
[INFO] |  +- org.apache.cassandra.deps:avro:jar:1.4.0-cassandra-1:compile
[INFO] |  |  - org.mortbay.jetty:jetty:jar:6.1.22:compile
[INFO] |  |     +- org.mortbay.jetty:jetty-util:jar:6.1.22:compile
[INFO] |  |     - org.mortbay.jetty:servlet-api:jar:2.5-20081211:provided (scope managed from compile)
[INFO] |  +- org.codehaus.jackson:jackson-core-asl:jar:1.4.0:compile
[INFO] |  +- org.codehaus.jackson:jackson-mapper-asl:jar:1.4.0:compile
[INFO] |  +- jline:jline:jar:0.9.94:compile
[INFO] |  +- com.googlecode.json-simple:json-simple:jar:1.1:compile
[INFO] |  +- com.github.stephenc.high-scale-lib:high-scale-lib:jar:1.1.2:compile
[INFO] |  +- org.yaml:snakeyaml:jar:1.6:compile
[INFO] |  +- edu.stanford.ppl:snaptree:jar:0.1:compile
[INFO] |  +- com.yammer.metrics:metrics-core:jar:2.0.3:compile
[INFO] |  +- log4j:log4j:jar:1.2.16:compile
[INFO] |  +- org.slf4j:slf4j-log4j12:jar:1.6.1:runtime
[INFO] |  +- org.apache.thrift:libthrift:jar:0.7.0:compile
[INFO] |  |  +- javax.servlet:servlet-api:jar:2.5:compile
[INFO] |  |  - org.apache.httpcomponents:httpclient:jar:4.0.1:compile
[INFO] |  |     +- org.apache.httpcomponents:httpcore:jar:4.0.1:compile
[INFO] |  |     - commons-logging:commons-logging:jar:1.1.1:compile
[INFO] |  - org.apache.cassandra:cassandra-thrift:jar:1.1.0:compile

To keep dependencies minimal, hector shouldn't depend on cassandra-all, just cassandra-thrift
