### PR TITLE
Handle Composite's name serialization properly

### DIFF
--- a/core/src/main/java/me/prettyprint/cassandra/serializers/CompositeSerializer.java
+++ b/core/src/main/java/me/prettyprint/cassandra/serializers/CompositeSerializer.java
@@ -6,7 +6,10 @@ package me.prettyprint.cassandra.serializers;
 import static me.prettyprint.hector.api.ddl.ComparatorType.COMPOSITETYPE;
 
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
 
+import me.prettyprint.hector.api.Serializer;
 import me.prettyprint.hector.api.beans.Composite;
 import me.prettyprint.hector.api.ddl.ComparatorType;
 
@@ -15,16 +18,16 @@ import me.prettyprint.hector.api.ddl.ComparatorType;
  * 
  */
 public class CompositeSerializer extends AbstractSerializer<Composite> {
-
-  private static final CompositeSerializer INSTANCE = new CompositeSerializer();
+    List<Serializer<?> > serializers = new ArrayList<Serializer<?>>();
   
   public static CompositeSerializer get() {
-    return INSTANCE;
+    return new CompositeSerializer();
   }
   
   @Override
   public ByteBuffer toByteBuffer(Composite obj) {
-
+    
+    serializers = obj.getSerializersByPosition();
     return obj.serialize();
   }
 
@@ -32,6 +35,9 @@ public class CompositeSerializer extends AbstractSerializer<Composite> {
   public Composite fromByteBuffer(ByteBuffer byteBuffer) {
 
     Composite composite = new Composite();
+    if (serializers.size() > 0) {
+        composite.setSerializersByPosition(serializers);
+    }
     composite.deserialize(byteBuffer);
 
     return composite;
@@ -43,4 +49,11 @@ public class CompositeSerializer extends AbstractSerializer<Composite> {
     return COMPOSITETYPE;
   }
 
+  public void addSerializers(Serializer<?> s) {
+    serializers.add(s);
+  }
+  
+  public void clearSerializers() {
+    serializers.clear();
+  }
 }

--- a/core/src/main/java/me/prettyprint/hector/api/beans/AbstractComposite.java
+++ b/core/src/main/java/me/prettyprint/hector/api/beans/AbstractComposite.java
@@ -421,6 +421,7 @@ public abstract class AbstractComposite extends AbstractList<Object> implements
     }
     components.add(index, new Component(element, null, s, c,
         equality));
+    setSerializerByPosition(index, s);
     return this;
   }
     

--- a/core/src/test/java/me/prettyprint/cassandra/serializers/CompositeSerializerTest.java
+++ b/core/src/test/java/me/prettyprint/cassandra/serializers/CompositeSerializerTest.java
@@ -1,0 +1,33 @@
+package me.prettyprint.cassandra.serializers;
+
+import static org.junit.Assert.assertEquals;
+
+import java.nio.ByteBuffer;
+import me.prettyprint.hector.api.beans.Composite;
+import org.junit.Test;
+
+public class CompositeSerializerTest {
+
+    @Test
+    public void testCompositeSerializeAndBack() {
+      Composite c = new Composite("hello", "world", 3L);
+      CompositeSerializer cs = new CompositeSerializer();
+      ByteBuffer bb = cs.toByteBuffer(c);
+      Composite c1 = cs.fromByteBuffer(bb);
+      assertEquals(c.hashCode(), c1.hashCode());
+    }
+    
+    @Test
+    public void testCreateSerializer() {
+      Composite c = new Composite("hello", "world", 1L);
+      CompositeSerializer cs = new CompositeSerializer();
+      ByteBuffer bb = cs.toByteBuffer(c);
+        
+      CompositeSerializer cs1 = new CompositeSerializer();
+      cs1.addSerializers(StringSerializer.get());
+      cs1.addSerializers(StringSerializer.get());
+      cs1.addSerializers(LongSerializer.get());
+      Composite c1 = cs1.fromByteBuffer(bb);
+      assertEquals(c.hashCode(), c1.hashCode());
+    }
+}


### PR DESCRIPTION
When a composite is serialized and then deserialized, the components of composite are typed as ByteBuffer. This patch enables the use of right kind of serializers for composite. 

This patch contains the following:
1. When a composite is constructed or components are added, the serializer list is initialized properly.
2. CompositeSerializer stores the list of serializers, so that the same serializers can be applied while deserializing.
3. CompositeSerializer now includes methods to set the serializers, so that query results can be constructed properly.
4. Remove the singleton CompositeSerializer since it would contain instance specific data (serializer list)
5. Test cases to test the new CompositeSerializer
