### PR TITLE
Fix For #425 (Provide More Granular Control Over Failover Behavior)

### DIFF
--- a/core/src/main/java/me/prettyprint/cassandra/connection/HConnectionManager.java
+++ b/core/src/main/java/me/prettyprint/cassandra/connection/HConnectionManager.java
@@ -272,7 +272,7 @@ public class HConnectionManager {
           closeClient(client);
           markHostAsDown(pool.getCassandraHost());
           excludeHosts.add(pool.getCassandraHost());
-          retryable = true;
+          retryable = op.failoverPolicy.shouldRetryFor(HectorTransportException.class);
 
           monitor.incCounter(Counter.RECOVERABLE_TRANSPORT_EXCEPTIONS);
 
@@ -281,14 +281,14 @@ public class HConnectionManager {
           // if HLT.checkTimeout(cassandraHost): suspendHost(cassandraHost);
           doTimeoutCheck(pool.getCassandraHost());
 
-          retryable = true;
+          retryable = op.failoverPolicy.shouldRetryFor(HTimedOutException.class);
 
           monitor.incCounter(Counter.RECOVERABLE_TIMED_OUT_EXCEPTIONS);
           client.close();
           // TODO timecheck on how long we've been waiting on timeouts here
           // suggestion per user moores on hector-users
         } else if ( he instanceof HPoolRecoverableException ) {
-          retryable = true;
+          retryable = op.failoverPolicy.shouldRetryFor(HPoolRecoverableException.class);;
           if ( hostPools.size() == 1 ) {
             throw he;
           }

--- a/core/src/main/java/me/prettyprint/cassandra/service/FailoverPolicy.java
+++ b/core/src/main/java/me/prettyprint/cassandra/service/FailoverPolicy.java
@@ -1,5 +1,10 @@
 package me.prettyprint.cassandra.service;
 
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Set;
+
 /**
  * What should the client do if a call to cassandra node fails and we suspect that the node is
  * down. (e.g. it's a communication error, not an application error).
@@ -13,7 +18,7 @@ package me.prettyprint.cassandra.service;
  * up and returning the communication error to the user.
  *
  */
-public class FailoverPolicy {
+public class FailoverPolicy<E extends Throwable> {
 
   /** On communication failure, just return the error to the client and don't retry */
   public static FailoverPolicy FAIL_FAST = new FailoverPolicy(0, 0);
@@ -26,8 +31,37 @@ public class FailoverPolicy {
 
   public final int sleepBetweenHostsMilli;
 
+  /** Optional set of classes representing Exceptions/Errors for which retry should not happen. */
+  public final Set<Class<E>> dontRetry;
+
   public FailoverPolicy(int numRetries, int sleepBwHostsMilli) {
     this.numRetries = numRetries;
     sleepBetweenHostsMilli = sleepBwHostsMilli;
+    dontRetry = ImmutableSet.of();
+  }
+
+  public FailoverPolicy(int numRetries, int sleepBwHostsMilli, Class<E> dontRetryForType) {
+    this.numRetries = numRetries;
+    sleepBetweenHostsMilli = sleepBwHostsMilli;
+    dontRetry = ImmutableSet.of(dontRetryForType);
+  }
+
+  public FailoverPolicy(int numRetries, int sleepBwHostsMilli, Set<Class<E>> dontRetryForTypes) {
+    this.numRetries = numRetries;
+    sleepBetweenHostsMilli = sleepBwHostsMilli;
+    this.dontRetry = dontRetryForTypes;
+  }
+
+  /**
+   * Determines if a given class is an exception or error that this FailoverPolicy supports retry for.
+   * This is a supplement to the explicit behavior defined in {@link me.prettyprint.cassandra.connection.HConnectionManager}.
+   */
+  public boolean shouldRetryFor(Class<E> candidate) {
+    Preconditions.checkNotNull(candidate, "Requires a non-null candidate class");
+    if (dontRetry != null) {
+      return !dontRetry.contains(candidate);
+    } else {
+      return true;
+    }
   }
 }


### PR DESCRIPTION
Add optional dontRetry property to FailoverPolicy, holding an optional set of classes representing Exceptions for which retry should not happen. This allows more granularity e.g. to avoid retry when counter writes experience HTimedOutException.
