### PR TITLE
Revert Test Connection On Borrow

### DIFF
--- a/core/src/main/java/me/prettyprint/cassandra/connection/ConcurrentHClientPool.java
+++ b/core/src/main/java/me/prettyprint/cassandra/connection/ConcurrentHClientPool.java
@@ -15,7 +15,6 @@ import me.prettyprint.hector.api.exceptions.HPoolExhaustedException;
 import me.prettyprint.hector.api.exceptions.HectorException;
 import me.prettyprint.hector.api.exceptions.HectorTransportException;
 
-import org.apache.thrift.TException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -64,19 +63,6 @@ public class ConcurrentHClientPool implements HClientPool {
 
   @Override
   public HClient borrowClient() throws HectorException {
-
-    HClient client = borrowClientImpl();
-    //TODO: make timeout configurable, 0 to disable
-    while ( !client.testClient(100) ) {
-      client.close();
-      releaseClient(client);
-      client = borrowClientImpl();
-    }
-    return client;
-  }
-
-  protected HClient borrowClientImpl() throws HectorException {
-
     if ( !active.get() ) {
       throw new HInactivePoolException("Attempt to borrow on in-active pool: " + getName());
     }

--- a/core/src/main/java/me/prettyprint/cassandra/connection/client/HClient.java
+++ b/core/src/main/java/me/prettyprint/cassandra/connection/client/HClient.java
@@ -111,10 +111,4 @@ public interface HClient {
    */
   void clearAuthentication();
 
-  /**
-   * Test if the client connection is working
-   * @param timeout the timeout to wait for a response (e.g. 100 ms)
-   * @return true iff the client received a response from Cassandra within the specified timeout, otherwise false
-   */
-  boolean testClient(int timeout);
 }

--- a/core/src/main/java/me/prettyprint/cassandra/connection/client/HThriftClient.java
+++ b/core/src/main/java/me/prettyprint/cassandra/connection/client/HThriftClient.java
@@ -38,7 +38,6 @@ public class HThriftClient implements HClient {
   protected String keyspaceName;
   private long useageStartTime;
 
-  protected TSocket socket;
   protected TTransport transport;
   protected Cassandra.Client cassandraClient;
 
@@ -121,7 +120,7 @@ public class HThriftClient implements HClient {
       log.debug("Creating a new thrift connection to {}", cassandraHost);
     }
 
-    socket = new TSocket(cassandraHost.getHost(), cassandraHost.getPort(), timeout);
+    TSocket socket = new TSocket(cassandraHost.getHost(), cassandraHost.getPort(), timeout);
     if ( cassandraHost.getUseSocketKeepalive() ) {
       try {
         socket.getSocket().setKeepAlive(true);
@@ -245,20 +244,5 @@ public class HThriftClient implements HClient {
   public void setAuthenticated(Map<String, String> credentials) {
     clearAuthentication();
     this.credentials.putAll(credentials);
-  }
-
-  public boolean testClient(int timeout) {
-    try {
-      //test client with "low" timeout
-      socket.setTimeout(timeout);
-      getCassandra().describe_cluster_name();
-    } catch (TException te) {
-      log.info("connection " + socket.toString() + " tested bad with timeout of " + timeout + " ms");
-      close();
-      return false;
-    }
-    //restore timeout if test was successful
-    socket.setTimeout(cassandraHost.getCassandraThriftSocketTimeout());
-    return true;
   }
 }


### PR DESCRIPTION
Until there's a better solution, I propose reverting the connection testing introduced by https://github.com/hector-client/hector/pull/499.

This reverts commit 3b829e3cdd6aeca4ddc9d61493b8c5cd67601801.

Conflicts:

```
core/src/main/java/me/prettyprint/cassandra/connection/ConcurrentHClientPool.java
```
