### PR TITLE
Added key validation alias support to the templates

### DIFF
--- a/core/src/main/java/me/prettyprint/cassandra/model/BasicColumnFamilyDefinition.java
+++ b/core/src/main/java/me/prettyprint/cassandra/model/BasicColumnFamilyDefinition.java
@@ -30,6 +30,7 @@ public class BasicColumnFamilyDefinition implements ColumnFamilyDefinition {
   private int gcGraceSeconds;
   private String defaultValidationClass;
   private String keyValidationClass;
+	private String keyValidationAlias = "";
   private int id;
   private int maxCompactionThreshold;
   private int minCompactionThreshold;
@@ -188,6 +189,10 @@ public class BasicColumnFamilyDefinition implements ColumnFamilyDefinition {
       this.keyValidationClass = keyValidationClass;
   }
 
+	public void setKeyValidationAlias(String keyValidationAlias) {
+		this.keyValidationAlias = keyValidationAlias;
+	}
+
   /**
    * SHOULD THIS BE HERE? A COLUMN DEFINITION IS PART OF A KEYSPACE BY VIRTUE
    * OF BEING IN A KEYSPACE LIST
@@ -303,6 +308,11 @@ public class BasicColumnFamilyDefinition implements ColumnFamilyDefinition {
   public String getKeyValidationClass() {
       return keyValidationClass;
   }
+
+	@Override
+	public String getKeyValidationAlias() {
+		return keyValidationAlias;
+	}
 
   @Override
   public String getCompactionStrategy() {

--- a/core/src/main/java/me/prettyprint/cassandra/service/ThriftCfDef.java
+++ b/core/src/main/java/me/prettyprint/cassandra/service/ThriftCfDef.java
@@ -34,6 +34,7 @@ public class ThriftCfDef implements ColumnFamilyDefinition {
   private List<ColumnDefinition> columnMetadata;
   private int gcGraceSeconds;
   private String keyValidationClass;
+	private String keyValidationAlias = "";
   private String defaultValidationClass;
   private int id;
   private int maxCompactionThreshold;
@@ -106,6 +107,7 @@ public class ThriftCfDef implements ColumnFamilyDefinition {
     keyCacheSize = columnFamilyDefinition.getKeyCacheSize();
     keyCacheSavePeriodInSeconds = columnFamilyDefinition.getKeyCacheSavePeriodInSeconds();
     keyValidationClass = columnFamilyDefinition.getKeyValidationClass();
+		keyValidationAlias = columnFamilyDefinition.getKeyValidationAlias();
     readRepairChance = columnFamilyDefinition.getReadRepairChance();
     columnMetadata = columnFamilyDefinition.getColumnMetadata();
     gcGraceSeconds = columnFamilyDefinition.getGcGraceSeconds();
@@ -266,7 +268,12 @@ public class ThriftCfDef implements ColumnFamilyDefinition {
     
     d.setKey_cache_size(keyCacheSize);
     d.setKey_cache_save_period_in_seconds(keyCacheSavePeriodInSeconds);
-    d.setKey_validation_class(keyValidationClass);
+		if(false || keyValidationClass != null) {
+			d.setKey_validation_class(keyValidationClass + keyValidationAlias);
+		} else {
+			d.setKey_validation_class(keyValidationClass);
+		}
+		
     d.setMax_compaction_threshold(maxCompactionThreshold);
     d.setMin_compaction_threshold(minCompactionThreshold);
     d.setRead_repair_chance(readRepairChance);
@@ -299,6 +306,11 @@ public class ThriftCfDef implements ColumnFamilyDefinition {
       return keyValidationClass;
   }
 
+	@Override
+	public String getKeyValidationAlias() {
+		return keyValidationAlias;
+	}
+	
   @Override
   public int getId() {
     return id;
@@ -371,6 +383,10 @@ public class ThriftCfDef implements ColumnFamilyDefinition {
       this.keyValidationClass = keyValidationClass;
   }
 
+	public void setKeyValidationAlias(String keyValidationAlias) {
+		this.keyValidationAlias = keyValidationAlias;
+	}
+	
   public void setId(int id) {
     this.id = id;
   }

--- a/core/src/main/java/me/prettyprint/hector/api/ddl/ColumnFamilyDefinition.java
+++ b/core/src/main/java/me/prettyprint/hector/api/ddl/ColumnFamilyDefinition.java
@@ -50,7 +50,10 @@ public interface ColumnFamilyDefinition {
   
   String getKeyValidationClass();
   void setKeyValidationClass(String keyValidationClass);
-  
+
+	String getKeyValidationAlias();
+	void setKeyValidationAlias(String keyValidationAlias);
+	
   double getReadRepairChance();
   void setReadRepairChance(double readRepairChance);
   


### PR DESCRIPTION
Due to DynamicComposite aliasing, Cassandra failed to create a CFD if the key type was DynamicComposite.  This request provides setter/getter methods so the user can set the alias via the templates. 
