### PR TITLE
Fix for JaxbSerializer

### DIFF
--- a/README
+++ b/README
@@ -19,7 +19,7 @@ Some features provided by this client:
  o high level, simple object oriented interface to cassandra
  o failover behavior on the client side
  o connection pooling for improved performance and scalability
- o JMX conters for monitoring and management
+ o JMX counters for monitoring and management
  o configurable and extensible load balancing with three algorithms to choose from: round robin (the default), least active, and a phi-accrural style response time detector
  o complete encapsulation of the underlying Thrift API and structs
  o automatic retry of downed hosts

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -7,7 +7,7 @@
   </parent>
   
   <artifactId>hector-core</artifactId>
-  <packaging>bundle</packaging>
+  <packaging>jar</packaging>
   <name>hector-core</name>
   <properties>
     <!-- OSGi bundle properties -->

--- a/core/src/main/java/me/prettyprint/cassandra/serializers/JaxbSerializer.java
+++ b/core/src/main/java/me/prettyprint/cassandra/serializers/JaxbSerializer.java
@@ -110,7 +110,9 @@ public class JaxbSerializer extends AbstractSerializer<Object> {
       return null;
     }
 
-    ByteArrayInputStream bais = new ByteArrayInputStream(bytes.array());
+    int l = bytes.remaining();
+    ByteArrayInputStream bais = new ByteArrayInputStream(bytes.array(),
+        bytes.arrayOffset() + bytes.position(), l);
     try {
       XMLStreamReader reader = createStreamReader(bais);
       Object ret = unmarshaller.get().unmarshal(reader);

--- a/core/src/test/java/me/prettyprint/cassandra/serializers/SerializerBaseTest.java
+++ b/core/src/test/java/me/prettyprint/cassandra/serializers/SerializerBaseTest.java
@@ -1,12 +1,12 @@
 package me.prettyprint.cassandra.serializers;
 
+import java.nio.ByteBuffer;
 import java.util.Collection;
 
 import junit.framework.Assert;
+import me.prettyprint.hector.api.Serializer;
 
 import org.junit.Test;
-
-import me.prettyprint.hector.api.Serializer;
 
 /**
  * A base test class for {@link Serializer}s. <br>
@@ -39,6 +39,29 @@ public abstract class SerializerBaseTest<T> {
   public void testNullObjectRoundTrip() {
     Assert.assertNull(getSerializer().fromByteBuffer(
         getSerializer().toByteBuffer(null)));
+  }
+  
+  @Test
+  public void testByteBufferWithSharedBackingArrayIsOk()
+  {
+	  for (T object : getTestData()) {
+		  byte[] bytes = getSerializer().toBytes(object);
+		  ByteBuffer byteBufferWithSharedBackingArray = copyIntoLargerArrayAndWrap(bytes);
+	      T deserialized = getSerializer().fromByteBuffer(byteBufferWithSharedBackingArray);
+	      Assert.assertEquals(object, deserialized);
+	  }
+  }
+
+  private ByteBuffer copyIntoLargerArrayAndWrap(byte[] bytes) {
+	int paddingLeft = 5;
+	  int paddingRight = 5;		  
+	  byte[] sharedBytesWithOtherStuff = new byte[bytes.length+paddingLeft+paddingRight];
+	  for (int i=0; i<bytes.length; i++)
+	  {
+		  sharedBytesWithOtherStuff[i+paddingLeft] = bytes[i];
+	  }
+	  ByteBuffer byteBufferWithSharedBackingArray = ByteBuffer.wrap(sharedBytesWithOtherStuff, paddingLeft, bytes.length);
+	return byteBufferWithSharedBackingArray;
   }
 
   /**

--- a/pom.xml
+++ b/pom.xml
@@ -197,23 +197,6 @@
   </dependencyManagement>
 
   <build>
-    <extensions>
-      <extension>
-        <groupId>org.apache.maven.scm</groupId>
-        <artifactId>maven-scm-provider-gitexe</artifactId>
-        <version>1.3</version>
-      </extension>
-      <extension>
-        <groupId>org.apache.maven.scm</groupId>
-        <artifactId>maven-scm-manager-plexus</artifactId>
-        <version>1.3</version>
-      </extension>
-      <extension>
-        <groupId>org.kathrynhuxtable.maven.wagon</groupId>
-        <artifactId>wagon-gitsite</artifactId>
-        <version>0.3.1</version>
-      </extension>
-    </extensions>
     <plugins>
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>


### PR DESCRIPTION
That's a minor fix(2 lines) and a test for JaxbSerializer.

It was not working properly when a ByteArray supplied to it actually was backed by byte[] array shared with someone other. Serializer took the whole byte[] array, thus failing to deserialize a column.

Test supplied makes sure that the issue won't reproduce with other Serializers.
