### PR TITLE
Remove dupe non-tmp saved_caches_directory entry in cassandra.yaml

### DIFF
--- a/core/src/test/resources/cassandra.yaml
+++ b/core/src/test/resources/cassandra.yaml
@@ -66,8 +66,6 @@ data_file_directories:
 # commit log
 commitlog_directory: tmp/var/lib/cassandra/commitlog
 
-saved_caches_directory: tmp/var/lib/cassandra/saved_caches
-
 # Maximum size of the key cache in memory.
 #
 # Each key cache hit saves 1 seek and each row cache hit saves 2 seeks at the
@@ -135,7 +133,7 @@ row_cache_save_period: 0
 row_cache_provider: SerializingCacheProvider
 
 # saved caches
-saved_caches_directory: /var/lib/cassandra/saved_caches
+saved_caches_directory: tmp/var/lib/cassandra/saved_caches
 
 # commitlog_sync may be either "periodic" or "batch." 
 # When in batch mode, Cassandra won't ack writes until the commit log


### PR DESCRIPTION
Fix failing tests - remove old duplicate saved_caches_directory entry leaving zznate's fix for relative location under tmp directory.
