### PR TITLE
Support for Cassandras DoubleType and FloatType

### DIFF
--- a/core/src/main/java/me/prettyprint/cassandra/serializers/DoubleTypeSerializer.java
+++ b/core/src/main/java/me/prettyprint/cassandra/serializers/DoubleTypeSerializer.java
@@ -1,0 +1,34 @@
+package me.prettyprint.cassandra.serializers;
+
+import java.nio.ByteBuffer;
+/**
+ * Serialization class to use with Cassandras DoubleType.
+ * 
+ * @author Felix Obenauer 
+ */
+public class DoubleTypeSerializer extends AbstractSerializer<Double> {
+	
+	private static final DoubleTypeSerializer instance = new DoubleTypeSerializer();
+
+	public static DoubleTypeSerializer get() {
+		return instance;
+	
+	}
+	@Override
+	public ByteBuffer toByteBuffer(Double obj) {
+		if (obj == null) {
+		      return null;
+		    }
+		byte[] bytes = new byte[8];
+	    ByteBuffer result = ByteBuffer.wrap(bytes).putDouble(obj);
+	    result.rewind();
+	    return result;
+	}
+
+	@Override
+	public Double fromByteBuffer(ByteBuffer byteBuffer) {
+		double result = byteBuffer.getDouble();
+		return result;
+	}
+
+}

--- a/core/src/main/java/me/prettyprint/cassandra/serializers/FloatTypeSerializer.java
+++ b/core/src/main/java/me/prettyprint/cassandra/serializers/FloatTypeSerializer.java
@@ -1,0 +1,34 @@
+package me.prettyprint.cassandra.serializers;
+
+import java.nio.ByteBuffer;
+/**
+ * Serialization class to use with Cassandras FloatType.
+ * 
+ * @author Felix Obenauer 
+ */
+public class FloatTypeSerializer extends AbstractSerializer<Float> {
+	
+	private static final FloatTypeSerializer instance = new FloatTypeSerializer();
+
+	public static FloatTypeSerializer get() {
+		return instance;
+	
+	}
+	@Override
+	public ByteBuffer toByteBuffer(Float obj) {
+		if (obj == null) {
+		      return null;
+		    }
+		byte[] bytes = new byte[4];
+	    ByteBuffer result = ByteBuffer.wrap(bytes).putFloat(obj);
+	    result.rewind();
+	    return result;
+	}
+
+	@Override
+	public Float fromByteBuffer(ByteBuffer byteBuffer) {
+		float result = byteBuffer.getFloat();
+		return result;
+	}
+
+}

--- a/core/src/main/java/me/prettyprint/hector/api/ddl/ComparatorType.java
+++ b/core/src/main/java/me/prettyprint/hector/api/ddl/ComparatorType.java
@@ -34,13 +34,17 @@ public final class ComparatorType {
       "org.apache.cassandra.db.marshal.UUIDType");
   public static final ComparatorType COUNTERTYPE = new ComparatorType(
       "org.apache.cassandra.db.marshal.CounterColumnType");
+  public static final ComparatorType DOUBLETYPE = new ComparatorType(
+		  "org.apache.cassandra.db.marshal.DoubleType");
+  public static final ComparatorType FLOATTYPE = new ComparatorType(
+		  "org.apache.cassandra.db.marshal.FloatType");  
 
   private static final Map<String, ComparatorType> valuesMap;
 
   static {
     ComparatorType[] types = { ASCIITYPE, BYTESTYPE, INTEGERTYPE,
         LEXICALUUIDTYPE, LOCALBYPARTITIONERTYPE, LONGTYPE, TIMEUUIDTYPE,
-        UTF8TYPE, COMPOSITETYPE, DYNAMICCOMPOSITETYPE, UUIDTYPE, COUNTERTYPE };
+        UTF8TYPE, COMPOSITETYPE, DYNAMICCOMPOSITETYPE, UUIDTYPE, COUNTERTYPE, DOUBLETYPE, FLOATTYPE };
 
     ImmutableMap.Builder<String, ComparatorType> builder =
         new ImmutableMap.Builder<String, ComparatorType>();


### PR DESCRIPTION
As discussed on the user group [1], I have added support for Cassandras DoubleType and FloatType. It's just a few lines of code and I tested it with my application, storing and retrieving double and float values. Code review would be very much appreciated, though.

[1] https://groups.google.com/forum/?fromgroups=#!topic/hector-users/pG3FMdpMaFo
