### PR TITLE
Fix ClassNotFoundException when runing in OSGi container

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -73,6 +73,7 @@
               !org.antlr.*,
               !jline.*,
               !sun.misc.*,
+              org.apache.cassandra.thrift,
               *;resolution:=optional
             </Import-Package>
             <Private-Package>


### PR DESCRIPTION
see https://github.com/hector-client/hector/issues/571

btw it's possible that some of the other dependencies are non-optional as well, but just happen to always be available in my environment (Geronimo) - if so they should also be defined as non-optional in the bundle plugin configuration.
