### PR TITLE
Add other constructors for StringKeyIterator

### DIFF
--- a/core/src/main/java/me/prettyprint/cassandra/service/KeyIterator.java
+++ b/core/src/main/java/me/prettyprint/cassandra/service/KeyIterator.java
@@ -72,18 +72,25 @@ public class KeyIterator<K> implements Iterable<K> {
     }
   }
 
+  @Deprecated
   public KeyIterator(Keyspace keyspace, String columnFamily, Serializer<K> serializer) {
     this(keyspace, columnFamily, serializer, null, null, MAX_ROW_COUNT_DEFAULT);
   }
 
+  @Deprecated
   public KeyIterator(Keyspace keyspace, String columnFamily, Serializer<K> serializer, int maxRowCount) {
     this(keyspace, columnFamily, serializer, null, null, maxRowCount);
   }
-  
+
+  @Deprecated
   public KeyIterator(Keyspace keyspace, String columnFamily, Serializer<K> serializer, K start, K end) {
     this(keyspace, columnFamily, serializer, start, end, MAX_ROW_COUNT_DEFAULT);
   }
 
+  @Deprecated
+  /*
+  * When pulling deprecated methods out, do not remove this but change it to private constructor
+  */
   public KeyIterator(Keyspace keyspace, String columnFamily, Serializer<K> serializer, K start, K end, int maxRowCount) {
     query = HFactory
       .createRangeSlicesQuery(keyspace, serializer, stringSerializer, stringSerializer)
@@ -109,7 +116,7 @@ public class KeyIterator<K> implements Iterable<K> {
 
     firstRun = false;
 
-    if (!rowsIterator.hasNext()) {
+    if (rowsIterator != null && !rowsIterator.hasNext()) {
       nextValue = null;    // all done.  our iterator's hasNext() will now return false;
     } else {
       findNext(true);
@@ -119,6 +126,50 @@ public class KeyIterator<K> implements Iterable<K> {
   @Override
   public Iterator<K> iterator() {
     return keyIterator;
+  }
+
+  public static class Builder<K> {
+
+    //required
+    private Keyspace keyspace;
+    private String columnFamily;
+    private Serializer<K> serializer;
+
+    //optional
+    private K start;
+    private K end;
+    private Integer maxRowCount;
+
+    public Builder(Keyspace keyspace, String columnFamily, Serializer<K> serializer) {
+      this.keyspace = keyspace;
+      this.columnFamily = columnFamily;
+      this.serializer = serializer;
+    }
+
+    public Builder<K> start(K start) {
+      this.start = start;
+      return this;
+    }
+
+    public Builder<K> end(K end) {
+      this.end = end;
+      return this;
+    }
+
+    public Builder<K> maxRowCount(int maxRowCount) {
+      this.maxRowCount = maxRowCount;
+      return this;
+    }
+
+    public KeyIterator<K> build() {
+      return new KeyIterator<K>(this);
+    }
+
+  }
+
+  protected KeyIterator(Builder<K> builder) {
+    this(builder.keyspace, builder.columnFamily, builder.serializer, builder.start, builder.end,
+            builder.maxRowCount == null? MAX_ROW_COUNT_DEFAULT : builder.maxRowCount);
   }
 }
 

--- a/core/src/main/java/me/prettyprint/cassandra/service/StringKeyIterator.java
+++ b/core/src/main/java/me/prettyprint/cassandra/service/StringKeyIterator.java
@@ -13,8 +13,43 @@ import me.prettyprint.hector.api.Keyspace;
  */
 public class StringKeyIterator extends KeyIterator<String> {
 
+  @Deprecated
   public StringKeyIterator(Keyspace keyspace, String columnFamily) {
     super(keyspace, columnFamily, new StringSerializer());
   }
 
+  public static class Builder extends KeyIterator.Builder<String> {
+
+    public Builder(Keyspace keyspace, String columnFamily) {
+      super(keyspace, columnFamily, new StringSerializer());
+    }
+
+    @Override
+    public Builder start(String start) {
+      super.start(start);
+      return this;
+    }
+
+    @Override
+    public Builder end(String end) {
+      super.end(end);
+      return this;
+    }
+
+    @Override
+    public Builder maxRowCount(int maxRowCount) {
+      super.maxRowCount(maxRowCount);
+      return this;
+    }
+
+    @Override
+    public StringKeyIterator build() {
+      return new StringKeyIterator(this);
+    }
+
+  }
+
+  private StringKeyIterator(Builder builder) {
+    super(builder);
+  }
 }

--- a/core/src/test/java/me/prettyprint/cassandra/service/KeyIteratorTest.java
+++ b/core/src/test/java/me/prettyprint/cassandra/service/KeyIteratorTest.java
@@ -50,13 +50,27 @@ public class KeyIteratorTest extends BaseEmbededServerSetupTest {
     assertKeys(5, "k5", null);
     assertKeys(9, null, null);
     assertKeys(7, null, "k7");
+
+    assertStringKeys(5, "k5", null);
+    assertStringKeys(9, null, null);
+    assertStringKeys(7, null, "k7");
   }
 
   private void assertKeys(int expected, String start, String end) {
-    Iterable<String> it = new KeyIterator<String>(keyspace, CF, se, start, end);
+    Iterable<String> it = new KeyIterator.Builder<String>(keyspace, CF, se).start(start).end(end).build();
 
     int tot = 0;
     for (String key : it)
+      tot++;
+
+    assertEquals(expected, tot);
+  }
+
+  private void assertStringKeys(int expected, String start, String end) {
+    StringKeyIterator sk = new StringKeyIterator.Builder(keyspace, CF).start(start).end(end).build();
+
+    int tot = 0;
+    for (String key : sk)
       tot++;
 
     assertEquals(expected, tot);


### PR DESCRIPTION
Most times, keys are strings and I find myself using StringKeyIterator to go through all keys (or list keys). And to have control over maxRowCount fetched at a time, I have to use KeyIterator<String>. Having other constructors in StringKeyIterator makes the job easier as the whole purpose of StringKeyIterator is to have an easy-readable alternative.

UPDATE: As suggested by Nate, refactored KeyIterator constructor to builder pattern.

Thanks,
