### PR TITLE
Add functionality to filter query results

### DIFF
--- a/core/src/main/java/me/prettyprint/cassandra/service/ColumnSliceIterator.java
+++ b/core/src/main/java/me/prettyprint/cassandra/service/ColumnSliceIterator.java
@@ -4,6 +4,7 @@ import com.google.common.collect.Iterators;
 import com.google.common.collect.PeekingIterator;
 import java.util.Iterator;
 import java.util.List;
+import me.prettyprint.cassandra.service.template.SliceFilter;
 import me.prettyprint.hector.api.beans.HColumn;
 import me.prettyprint.hector.api.query.SliceQuery;
 
@@ -21,7 +22,7 @@ public class ColumnSliceIterator<K, N, V> implements Iterator<HColumn<N, V>> {
 	private PeekingIterator<HColumn<N, V>> iterator;
 	private N start;
 	private ColumnSliceFinish<N> finish;
-	private ColumnSliceFilter<HColumn<N, V>> filter = null;
+	private SliceFilter<HColumn<N, V>> filter = null;
 	private boolean reversed;
 	private int count = DEFAULT_COUNT;
 	private int columns = 0;
@@ -89,7 +90,13 @@ public class ColumnSliceIterator<K, N, V> implements Iterator<HColumn<N, V>> {
 		this.query.setRange(this.start, this.finish.function(), this.reversed, this.count);
 	}
 
-	public ColumnSliceIterator setFilter(ColumnSliceFilter<HColumn<N, V>> filter) {
+	/**
+	 * Set a filter to determine which columns will be returned.
+	 *
+	 * @param filter Filter to determine which columns will be returned
+	 * @return &lt;this&gt;
+	 */
+	public ColumnSliceIterator setFilter(SliceFilter<HColumn<N, V>> filter) {
 		this.filter = filter;
 		return this;
 	}
@@ -158,9 +165,5 @@ public class ColumnSliceIterator<K, N, V> implements Iterator<HColumn<N, V>> {
 		 * @return New finish point
 		 */
 		N function();
-	}
-
-	public interface ColumnSliceFilter<C> {
-		boolean accept(C column);
 	}
 }

--- a/core/src/main/java/me/prettyprint/cassandra/service/template/SliceFilter.java
+++ b/core/src/main/java/me/prettyprint/cassandra/service/template/SliceFilter.java
@@ -1,0 +1,15 @@
+package me.prettyprint.cassandra.service.template;
+
+/**
+ *
+ * @author thrykol
+ */
+public interface SliceFilter<C>
+{
+	/**
+	 * Determine if the column should be included in the slice
+	 * @param column Column 
+	 * @return True if the column should be included, false otherwise
+	 */
+	boolean accept(C column);
+}

--- a/core/src/test/java/me/prettyprint/cassandra/service/ColumnSliceIteratorTest.java
+++ b/core/src/test/java/me/prettyprint/cassandra/service/ColumnSliceIteratorTest.java
@@ -8,6 +8,7 @@ import java.util.UUID;
 import me.prettyprint.cassandra.BaseEmbededServerSetupTest;
 import me.prettyprint.cassandra.serializers.StringSerializer;
 import me.prettyprint.cassandra.serializers.UUIDSerializer;
+import me.prettyprint.cassandra.service.template.SliceFilter;
 import me.prettyprint.cassandra.utils.TimeUUIDUtils;
 import me.prettyprint.hector.api.Cluster;
 import me.prettyprint.hector.api.Keyspace;
@@ -56,7 +57,7 @@ public class ColumnSliceIteratorTest extends BaseEmbededServerSetupTest {
 		m.execute();
 	}
 
-	//@Test
+	@Test
 	public void testIterator() {
 		SliceQuery<String, UUID, String> query = HFactory.createSliceQuery(keyspace, se, us, se).setKey(KEY).setColumnFamily(CF);
 		ColumnSliceIterator<String, UUID, String> it = new ColumnSliceIterator<String, UUID, String>(query, null, FINISH, false, 100);
@@ -69,7 +70,7 @@ public class ColumnSliceIteratorTest extends BaseEmbededServerSetupTest {
 		assertEquals(1000, results.size());
 	}
 
-	//@Test
+	@Test
 	public void testModificationIterator() {
 		Mutator mutator = HFactory.createMutator(keyspace, se);
 		SliceQuery<String, UUID, String> query = HFactory.createSliceQuery(keyspace, se, us, se).setKey(KEY).setColumnFamily(CF);
@@ -101,7 +102,7 @@ public class ColumnSliceIteratorTest extends BaseEmbededServerSetupTest {
 						.setKey(KEY)
 						.setColumnFamily(CF);
 		ColumnSliceIterator<String, String, String> it = new ColumnSliceIterator<String, String, String>(query, "a", "d", false, 2).
-						setFilter(new ColumnSliceIterator.ColumnSliceFilter<HColumn<String, String>>() {
+						setFilter(new SliceFilter<HColumn<String, String>>() {
 
 			@Override
 			public boolean accept(HColumn<String, String> column) {

--- a/core/src/test/java/me/prettyprint/cassandra/service/SliceCounterIteratorTest.java
+++ b/core/src/test/java/me/prettyprint/cassandra/service/SliceCounterIteratorTest.java
@@ -1,11 +1,14 @@
 package me.prettyprint.cassandra.service;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import me.prettyprint.cassandra.BaseEmbededServerSetupTest;
 import me.prettyprint.cassandra.serializers.StringSerializer;
 import me.prettyprint.cassandra.serializers.UUIDSerializer;
+import me.prettyprint.cassandra.service.template.SliceFilter;
 import me.prettyprint.cassandra.utils.TimeUUIDUtils;
 import me.prettyprint.hector.api.Cluster;
 import me.prettyprint.hector.api.Keyspace;
@@ -18,6 +21,7 @@ import org.junit.After;
 import static org.junit.Assert.assertEquals;
 import org.junit.Before;
 import org.junit.Test;
+import static org.junit.Assert.*;
 
 public class SliceCounterIteratorTest extends BaseEmbededServerSetupTest {
 
@@ -80,6 +84,41 @@ public class SliceCounterIteratorTest extends BaseEmbededServerSetupTest {
 			mutator.addDeletion(KEY, CF, c.getName(), us);
 			mutator.execute();
 		}
+		assertEquals(1000, results.size());
+	}
+
+	@Test
+	public void testFilter() {
+		cluster.truncate(keyspace.getKeyspaceName(), CF);
+
+		Mutator<String> m = createMutator(keyspace, se);
+		for (int i = 0; i < 500; i++) {
+			m.addCounter(KEY, CF, createCounterColumn("a" + i, 1, se));
+			m.addCounter(KEY, CF, createCounterColumn("b" + i, 1, se));
+			m.addCounter(KEY, CF, createCounterColumn("c" + i, 1, se));
+		}
+		m.execute();
+
+		SliceCounterQuery<String, String> query = HFactory.createCounterSliceQuery(keyspace, se, se).setKey(KEY).setColumnFamily(CF);
+		SliceCounterIterator<String, String> it = new SliceCounterIterator<String, String>(query, "a", "d", false, 100).setFilter(new SliceFilter<HCounterColumn<String>>() {
+
+			@Override
+			public boolean accept(HCounterColumn<String> column)
+			{
+				return !column.getName().startsWith("b");
+			}
+
+		});
+
+		List<String> results = new ArrayList<String>(1000);
+		while(it.hasNext()) {
+			HCounterColumn<String> c = it.next();
+			String name = c.getName();
+
+			assertFalse(name.equals("b"));
+			results.add(name);
+		}
+
 		assertEquals(1000, results.size());
 	}
 }


### PR DESCRIPTION
Often, a query will include results which are not actually desired.  To facilitate filtering out these results, I've introduced a filter interface which the caller can implement and pass to the iterator.  Only results which pass the filter's test will be included in the final results.
