### PR TITLE
Update guava to 14.0

### DIFF
--- a/core/src/main/java/me/prettyprint/hector/api/beans/AbstractComposite.java
+++ b/core/src/main/java/me/prettyprint/hector/api/beans/AbstractComposite.java
@@ -81,6 +81,8 @@ public abstract class AbstractComposite extends AbstractList<Object> implements
           AsciiSerializer.get().getComparatorType().getTypeName())
       .put(BigIntegerSerializer.class,
           BigIntegerSerializer.get().getComparatorType().getTypeName())
+      .put(ByteBufferSerializer.class,
+          ByteBufferSerializer.get().getComparatorType().getTypeName())
       .put(LongSerializer.class,
           LongSerializer.get().getComparatorType().getTypeName())
       .put(StringSerializer.class,

--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>r09</version>
+        <version>14.0</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Add ByteBufferSerializer to DEFAULT_SERIALIZER_TO_COMPARATOR_MAPPING

This is needed because AbstractComposite.serializerForComparator
throws NullPointerException if comparator doesn't exist in mapping
