### PR TITLE
hector removes downed host if ring info is empty

### DIFF
--- a/core/src/main/java/me/prettyprint/cassandra/connection/CassandraHostRetryService.java
+++ b/core/src/main/java/me/prettyprint/cassandra/connection/CassandraHostRetryService.java
@@ -131,6 +131,10 @@ public class CassandraHostRetryService extends BackgroundCassandraHostService {
       if( checkRing) {
         // Let's check the ring just once per cycle.
         ringInfo = buildRingInfo();
+        if (ringInfo!=null && ringInfo.isEmpty()) {
+          ringInfo = null;
+          log.warn("Got an empty ring info, maybe not enough permission");
+        }
       }
 
       Iterator<CassandraHost> iter = downedHostQueue.iterator();


### PR DESCRIPTION
If ring info is empty, hector removes downed host instantly. This can happen if there is there is some auth misconfiguration. A empty ring info is not a valid source of information, so it should not be used anyway.
