### PR TITLE
added JMX counters for renewed idle/too long connections + added/modified tests

### DIFF
--- a/core/src/main/java/me/prettyprint/cassandra/connection/ConcurrentHClientPool.java
+++ b/core/src/main/java/me/prettyprint/cassandra/connection/ConcurrentHClientPool.java
@@ -10,6 +10,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import me.prettyprint.cassandra.connection.client.HClient;
 import me.prettyprint.cassandra.connection.factory.HClientFactory;
 import me.prettyprint.cassandra.service.CassandraHost;
+import me.prettyprint.cassandra.service.CassandraClientMonitor;
+import me.prettyprint.cassandra.service.CassandraClientMonitor.Counter;
 import me.prettyprint.hector.api.exceptions.HInactivePoolException;
 import me.prettyprint.hector.api.exceptions.HPoolExhaustedException;
 import me.prettyprint.hector.api.exceptions.HectorException;
@@ -36,9 +38,12 @@ public class ConcurrentHClientPool implements HClientPool {
 
   private final HClientFactory clientFactory;
 
-  public ConcurrentHClientPool(HClientFactory clientFactory, CassandraHost host) {
+  private final CassandraClientMonitor monitor;
+
+  public ConcurrentHClientPool(HClientFactory clientFactory, CassandraHost host, CassandraClientMonitor monitor) {
     this.clientFactory = clientFactory;
     this.cassandraHost = host;
+    this.monitor = monitor;
 
     availableClientQueue = new ArrayBlockingQueue<HClient>(cassandraHost.getMaxActive(), true);
     // This counter can be offset by as much as the number of threads.
@@ -79,6 +84,8 @@ public class ConcurrentHClientPool implements HClientPool {
               System.currentTimeMillis() - cassandraClient.getLastSuccessTime());
           cassandraClient.close();
           cassandraClient = null;
+
+          monitor.incCounter(Counter.RENEWED_IDLE_CONNECTIONS);
 		}
       }
       if (cassandraClient != null) {
@@ -88,6 +95,8 @@ public class ConcurrentHClientPool implements HClientPool {
               System.currentTimeMillis() - cassandraClient.getCreatedTime());
           cassandraClient.close();
           cassandraClient = null;
+
+          monitor.incCounter(Counter.RENEWED_TOO_LONG_CONNECTIONS);
 		}
       }
       if ( cassandraClient == null ) {

--- a/core/src/main/java/me/prettyprint/cassandra/connection/DynamicLoadBalancingPolicy.java
+++ b/core/src/main/java/me/prettyprint/cassandra/connection/DynamicLoadBalancingPolicy.java
@@ -14,6 +14,7 @@ import java.util.concurrent.TimeUnit;
 
 import me.prettyprint.cassandra.connection.factory.HClientFactory;
 import me.prettyprint.cassandra.service.CassandraHost;
+import me.prettyprint.cassandra.service.CassandraClientMonitor;
 import me.prettyprint.cassandra.utils.DaemonThreadPoolFactory;
 
 import org.slf4j.Logger;
@@ -119,8 +120,8 @@ public class DynamicLoadBalancingPolicy implements LoadBalancingPolicy {
   }
 
   @Override
-  public HClientPool createConnection(HClientFactory clientFactory, CassandraHost host) {
-    LatencyAwareHClientPool pool = new LatencyAwareHClientPool(clientFactory, host);
+  public HClientPool createConnection(HClientFactory clientFactory, CassandraHost host, CassandraClientMonitor monitor) {
+    LatencyAwareHClientPool pool = new LatencyAwareHClientPool(clientFactory, host, monitor);
     add(pool);
     return pool;
   }

--- a/core/src/main/java/me/prettyprint/cassandra/connection/HConnectionManager.java
+++ b/core/src/main/java/me/prettyprint/cassandra/connection/HConnectionManager.java
@@ -62,9 +62,10 @@ public class HConnectionManager {
     if ( cassandraHostConfigurator.getRetryDownedHosts() ) {
       cassandraHostRetryService = new CassandraHostRetryService(this, clientFactory, cassandraHostConfigurator, listenerHandler);
     }
+    monitor = JmxMonitor.getInstance().getCassandraMonitor(this);
     for ( CassandraHost host : cassandraHostConfigurator.buildCassandraHosts()) {
       try {
-        HClientPool hcp = loadBalancingPolicy.createConnection(clientFactory, host);
+        HClientPool hcp = loadBalancingPolicy.createConnection(clientFactory, host, monitor);
         hostPools.put(host,hcp);
       } catch (HectorTransportException hte) {
         log.error("Could not start connection pool for host {}", host);
@@ -78,7 +79,6 @@ public class HConnectionManager {
     if ( cassandraHostConfigurator.getUseHostTimeoutTracker() ) {
       hostTimeoutTracker = new HostTimeoutTracker(this, cassandraHostConfigurator);
     }
-    monitor = JmxMonitor.getInstance().getCassandraMonitor(this);
     exceptionsTranslator = new ExceptionsTranslatorImpl();
     this.cassandraHostConfigurator = cassandraHostConfigurator;
     hostPoolValues = hostPools.values();
@@ -109,7 +109,7 @@ public class HConnectionManager {
       HClientPool pool = null;
       try {
         cassandraHostConfigurator.applyConfig(cassandraHost);
-        pool = cassandraHostConfigurator.getLoadBalancingPolicy().createConnection(clientFactory, cassandraHost);
+        pool = cassandraHostConfigurator.getLoadBalancingPolicy().createConnection(clientFactory, cassandraHost, monitor);
         hostPools.putIfAbsent(cassandraHost, pool);
         log.info("Added host {} to pool", cassandraHost.getName());
         listenerHandler.fireOnAddHost(cassandraHost, true, null, null);

--- a/core/src/main/java/me/prettyprint/cassandra/connection/LatencyAwareHClientPool.java
+++ b/core/src/main/java/me/prettyprint/cassandra/connection/LatencyAwareHClientPool.java
@@ -6,6 +6,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import me.prettyprint.cassandra.connection.client.HClient;
 import me.prettyprint.cassandra.connection.factory.HClientFactory;
 import me.prettyprint.cassandra.service.CassandraHost;
+import me.prettyprint.cassandra.service.CassandraClientMonitor;
 import me.prettyprint.hector.api.exceptions.HectorException;
 
 /**
@@ -22,8 +23,8 @@ public class LatencyAwareHClientPool extends ConcurrentHClientPool {
   private static final double SENTINEL_COMPARE = 0.768;
   private final LinkedBlockingDeque<Double> latencies;
 
-  public LatencyAwareHClientPool(HClientFactory clientFactory, CassandraHost host) {
-    super(clientFactory, host);
+  public LatencyAwareHClientPool(HClientFactory clientFactory, CassandraHost host, CassandraClientMonitor monitor) {
+    super(clientFactory, host, monitor);
     latencies = new LinkedBlockingDeque<Double>(WINDOW_QUEUE_SIZE);
   }
 

--- a/core/src/main/java/me/prettyprint/cassandra/connection/LeastActiveBalancingPolicy.java
+++ b/core/src/main/java/me/prettyprint/cassandra/connection/LeastActiveBalancingPolicy.java
@@ -2,6 +2,7 @@ package me.prettyprint.cassandra.connection;
 
 import me.prettyprint.cassandra.connection.factory.HClientFactory;
 import me.prettyprint.cassandra.service.CassandraHost;
+import me.prettyprint.cassandra.service.CassandraClientMonitor;
 
 import java.util.*;
 
@@ -55,7 +56,7 @@ public class LeastActiveBalancingPolicy implements LoadBalancingPolicy {
   }
   
   @Override
-  public HClientPool createConnection(HClientFactory clientFactory, CassandraHost host) {
-	  return new ConcurrentHClientPool(clientFactory, host);
+  public HClientPool createConnection(HClientFactory clientFactory, CassandraHost host, CassandraClientMonitor monitor) {
+	  return new ConcurrentHClientPool(clientFactory, host, monitor);
   }
 }

--- a/core/src/main/java/me/prettyprint/cassandra/connection/LoadBalancingPolicy.java
+++ b/core/src/main/java/me/prettyprint/cassandra/connection/LoadBalancingPolicy.java
@@ -6,6 +6,7 @@ import java.util.Set;
 
 import me.prettyprint.cassandra.connection.factory.HClientFactory;
 import me.prettyprint.cassandra.service.CassandraHost;
+import me.prettyprint.cassandra.service.CassandraClientMonitor;
 
 /**
  * Default interface for all load balancing policies.
@@ -27,7 +28,8 @@ public interface LoadBalancingPolicy extends Serializable {
    * 
    * @param clientFactory an instance of {@link HClientFactory}
    * @param host an instance of {@link CassandraHost} representing the host this pool will represent 
+   * @param monitor the monitor exposing JMX methods 
    * @return a connection pool
    */
-  HClientPool createConnection(HClientFactory clientFactory, CassandraHost host);
+  HClientPool createConnection(HClientFactory clientFactory, CassandraHost host, CassandraClientMonitor monitor);
 }

--- a/core/src/main/java/me/prettyprint/cassandra/connection/RoundRobinBalancingPolicy.java
+++ b/core/src/main/java/me/prettyprint/cassandra/connection/RoundRobinBalancingPolicy.java
@@ -5,6 +5,7 @@ import java.util.Set;
 
 import me.prettyprint.cassandra.connection.factory.HClientFactory;
 import me.prettyprint.cassandra.service.CassandraHost;
+import me.prettyprint.cassandra.service.CassandraClientMonitor;
 
 import com.google.common.collect.Iterables;
 
@@ -63,7 +64,7 @@ public class RoundRobinBalancingPolicy implements LoadBalancingPolicy {
   }
 
   @Override
-  public HClientPool createConnection(HClientFactory clientFactory, CassandraHost host) {
-  	return new ConcurrentHClientPool(clientFactory, host);
+  public HClientPool createConnection(HClientFactory clientFactory, CassandraHost host, CassandraClientMonitor monitor) {
+    return new ConcurrentHClientPool(clientFactory, host, monitor);
   }
 }

--- a/core/src/main/java/me/prettyprint/cassandra/service/CassandraClientMonitor.java
+++ b/core/src/main/java/me/prettyprint/cassandra/service/CassandraClientMonitor.java
@@ -40,6 +40,8 @@ public class CassandraClientMonitor implements CassandraClientMonitorMBean {
     RECOVERABLE_LB_CONNECT_ERRORS,
     /** Connection time errors - unable to connect to host or something... */
     CONNECT_ERROR,
+    RENEWED_IDLE_CONNECTIONS,
+    RENEWED_TOO_LONG_CONNECTIONS
   }
 
   public CassandraClientMonitor(HConnectionManager connectionManager) {
@@ -247,7 +249,14 @@ public class CassandraClientMonitor implements CassandraClientMonitorMBean {
       return false;
     }
   }
-  
-  
 
+  @Override
+  public int getNumRenewedIdleConnections() {
+    return counters.get(Counter.RENEWED_IDLE_CONNECTIONS).intValue();
+  }
+
+  @Override
+  public int getNumRenewedTooLongConnections() {
+    return counters.get(Counter.RENEWED_TOO_LONG_CONNECTIONS).intValue();
+  }
 }

--- a/core/src/main/java/me/prettyprint/cassandra/service/CassandraClientMonitorMBean.java
+++ b/core/src/main/java/me/prettyprint/cassandra/service/CassandraClientMonitorMBean.java
@@ -152,4 +152,16 @@ public interface CassandraClientMonitorMBean {
   Set<String> getSuspendedCassandraHosts();
 
   boolean setCassandraHostRetryDelay(String retryDelay);
+
+
+  /**
+   * Total number of connections created due to previous idle connections.
+   */
+  int getNumRenewedIdleConnections();
+
+
+  /**
+   * Total number of connections created due to previous too long connections.
+   */
+  int getNumRenewedTooLongConnections();
 }

--- a/core/src/test/java/me/prettyprint/cassandra/connection/ConcurrentHClientPoolTest.java
+++ b/core/src/test/java/me/prettyprint/cassandra/connection/ConcurrentHClientPoolTest.java
@@ -7,6 +7,7 @@ import me.prettyprint.cassandra.connection.client.HClient;
 import me.prettyprint.cassandra.connection.factory.HClientFactory;
 import me.prettyprint.cassandra.connection.factory.HThriftClientFactoryImpl;
 import me.prettyprint.cassandra.service.CassandraHost;
+import me.prettyprint.cassandra.service.CassandraClientMonitor;
 import me.prettyprint.hector.api.exceptions.HInactivePoolException;
 
 import org.junit.Before;
@@ -22,7 +23,7 @@ public class ConcurrentHClientPoolTest extends BaseEmbededServerSetupTest {
     setupClient();
     cassandraHost = cassandraHostConfigurator.buildCassandraHosts()[0];
     HClientFactory factory = new HThriftClientFactoryImpl();
-    clientPool = new ConcurrentHClientPool(factory, cassandraHost);
+    clientPool = new ConcurrentHClientPool(factory, cassandraHost, new CassandraClientMonitor(connectionManager));
   }
   
   @Test

--- a/core/src/test/java/me/prettyprint/cassandra/connection/LatencyAwareHClientPoolTest.java
+++ b/core/src/test/java/me/prettyprint/cassandra/connection/LatencyAwareHClientPoolTest.java
@@ -5,6 +5,7 @@ import me.prettyprint.cassandra.BaseEmbededServerSetupTest;
 import me.prettyprint.cassandra.connection.factory.HClientFactory;
 import me.prettyprint.cassandra.connection.factory.HThriftClientFactoryImpl;
 import me.prettyprint.cassandra.service.CassandraHost;
+import me.prettyprint.cassandra.service.CassandraClientMonitor;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -20,7 +21,7 @@ public class LatencyAwareHClientPoolTest extends BaseEmbededServerSetupTest {
     setupClient();
     cassandraHost = cassandraHostConfigurator.buildCassandraHosts()[0];
     HClientFactory factory = new HThriftClientFactoryImpl();
-    clientPool = new LatencyAwareHClientPool(factory, cassandraHost);
+    clientPool = new LatencyAwareHClientPool(factory, cassandraHost, new CassandraClientMonitor(connectionManager));
   }
 
   @Test


### PR DESCRIPTION
A new commit complementary to the previous ones about dealing with firewall's connection cuts.
