### PR TITLE
adding another test for the code that renew too long connections

### DIFF
--- a/core/src/test/java/me/prettyprint/cassandra/connection/HClientIdleConnectionRenewTest.java
+++ b/core/src/test/java/me/prettyprint/cassandra/connection/HClientIdleConnectionRenewTest.java
@@ -1,0 +1,56 @@
+package me.prettyprint.cassandra.connection;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.fail;
+import me.prettyprint.cassandra.BaseEmbededServerSetupTest;
+import me.prettyprint.cassandra.connection.client.HClient;
+import me.prettyprint.cassandra.connection.factory.HClientFactory;
+import me.prettyprint.cassandra.connection.factory.HThriftClientFactoryImpl;
+import me.prettyprint.cassandra.service.CassandraHost;
+import me.prettyprint.cassandra.service.CassandraClientMonitor;
+import me.prettyprint.cassandra.service.CassandraHostConfigurator;
+import me.prettyprint.hector.api.exceptions.HInactivePoolException;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class HClientIdleConnectionRenewTest extends BaseEmbededServerSetupTest {
+    
+  private CassandraHost cassandraHost;
+  private ConcurrentHClientPool clientPool;
+  private CassandraClientMonitor monitor;
+  
+  @Before
+  public void setupTest() {
+    setupClient();
+    cassandraHost = cassandraHostConfigurator.buildCassandraHosts()[0];
+    HClientFactory factory = new HThriftClientFactoryImpl();
+    monitor = new CassandraClientMonitor(connectionManager);
+    clientPool = new ConcurrentHClientPool(factory, cassandraHost, monitor);
+  } 
+  
+  protected void configure(CassandraHostConfigurator configurator) {
+    configurator.setMaxActive(1);
+    configurator.setMaxLastSuccessTimeMillis(3 * 1000);
+  }
+  
+  @Test
+  public void testBorrowAndRenew() {
+    HClient client1 = clientPool.borrowClient();
+    assertEquals(1, clientPool.getNumActive());
+	client1.updateLastSuccessTime();
+    clientPool.releaseClient(client1);
+    assertEquals(0, clientPool.getNumActive());
+    int count = monitor.getNumRenewedIdleConnections();
+	try {
+	  Thread.sleep(4 * 1000);
+    } catch(InterruptedException ex) {
+	  fail();
+	}
+    HClient client2 = clientPool.borrowClient();
+    assertEquals(1, clientPool.getNumActive());
+    assertEquals(count + 1, monitor.getNumRenewedIdleConnections());
+	assertNotSame(client1, client2);
+  }
+}

--- a/core/src/test/java/me/prettyprint/cassandra/connection/HClientTooLongConnectionRenewTest.java
+++ b/core/src/test/java/me/prettyprint/cassandra/connection/HClientTooLongConnectionRenewTest.java
@@ -15,7 +15,7 @@ import me.prettyprint.hector.api.exceptions.HInactivePoolException;
 import org.junit.Before;
 import org.junit.Test;
 
-public class HClientRenewTest extends BaseEmbededServerSetupTest {
+public class HClientTooLongConnectionRenewTest extends BaseEmbededServerSetupTest {
     
   private CassandraHost cassandraHost;
   private ConcurrentHClientPool clientPool;
@@ -32,7 +32,7 @@ public class HClientRenewTest extends BaseEmbededServerSetupTest {
   
   protected void configure(CassandraHostConfigurator configurator) {
     configurator.setMaxActive(1);
-    configurator.setMaxLastSuccessTimeMillis(3 * 1000);
+    configurator.setMaxConnectTimeMillis(3 * 1000);
   }
   
   @Test
@@ -42,7 +42,7 @@ public class HClientRenewTest extends BaseEmbededServerSetupTest {
 	client1.updateLastSuccessTime();
     clientPool.releaseClient(client1);
     assertEquals(0, clientPool.getNumActive());
-    int count = monitor.getNumRenewedIdleConnections();
+    int count = monitor.getNumRenewedTooLongConnections();
 	try {
 	  Thread.sleep(4 * 1000);
     } catch(InterruptedException ex) {
@@ -50,7 +50,7 @@ public class HClientRenewTest extends BaseEmbededServerSetupTest {
 	}
     HClient client2 = clientPool.borrowClient();
     assertEquals(1, clientPool.getNumActive());
-    assertEquals(count + 1, monitor.getNumRenewedIdleConnections());
+    assertEquals(count + 1, monitor.getNumRenewedTooLongConnections());
 	assertNotSame(client1, client2);
   }
 }


### PR DESCRIPTION
I coded the patch for renewing idle connections.

While the code for renewing too long connections is not mine, I found testing it was similar and then, I coded the corresponding test. Here it is.
