### PR TITLE
Make ConfigurableConsistencyLevel thread-safe at runtime by moving the call to consistencyLevelPolicy.get(operationType) and consistencyLevelPolicy.get(operationType,cfName) out of the anonymous class Operation<T>

### DIFF
--- a/core/src/main/java/me/prettyprint/cassandra/model/MutatorImpl.java
+++ b/core/src/main/java/me/prettyprint/cassandra/model/MutatorImpl.java
@@ -5,7 +5,13 @@ import java.util.Arrays;
 import me.prettyprint.cassandra.model.thrift.ThriftConverter;
 import me.prettyprint.cassandra.model.thrift.ThriftFactory;
 import me.prettyprint.cassandra.serializers.TypeInferringSerializer;
-import me.prettyprint.cassandra.service.*;
+import me.prettyprint.cassandra.service.BatchMutation;
+import me.prettyprint.cassandra.service.BatchSizeHint;
+import me.prettyprint.cassandra.service.KeyspaceService;
+import me.prettyprint.cassandra.service.Operation;
+import me.prettyprint.cassandra.service.OperationType;
+import me.prettyprint.hector.api.ConsistencyLevelPolicy;
+import me.prettyprint.hector.api.HConsistencyLevel;
 import me.prettyprint.hector.api.Keyspace;
 import me.prettyprint.hector.api.Serializer;
 import me.prettyprint.hector.api.beans.HColumn;
@@ -15,389 +21,452 @@ import me.prettyprint.hector.api.beans.HSuperColumn;
 import me.prettyprint.hector.api.exceptions.HectorException;
 import me.prettyprint.hector.api.mutation.MutationResult;
 import me.prettyprint.hector.api.mutation.Mutator;
+
 import org.apache.cassandra.thrift.Cassandra;
 import org.apache.cassandra.thrift.Deletion;
 import org.apache.cassandra.thrift.SlicePredicate;
 
-
-
 /**
- * A Mutator inserts or deletes values from the cluster.
- * There are two main ways to use a mutator:
- * 1. Use the insert/delete methods to immediately insert of delete values.
- * or 2. Use the addInsertion/addDeletion methods to schedule batch operations and then execute()
- * all of them in batch.
- *
+ * A Mutator inserts or deletes values from the cluster. There are two main ways to use a mutator: 1. Use the insert/delete methods to immediately insert of delete values. or 2. Use the
+ * addInsertion/addDeletion methods to schedule batch operations and then execute() all of them in batch.
+ * 
  * The class is not thread-safe.
- *
+ * 
  * @author Ran Tavory
  * @author zznate
  * @author patricioe
  */
-public final class MutatorImpl<K> implements Mutator<K> {
+public final class MutatorImpl<K> implements Mutator<K>
+{
 
-  private final ExecutingKeyspace keyspace;
+	private final ExecutingKeyspace keyspace;
 
-  protected final Serializer<K> keySerializer;
+	protected final Serializer<K> keySerializer;
 
-  private BatchMutation<K> pendingMutations;
-  
-  private BatchSizeHint sizeHint;
+	private BatchMutation<K> pendingMutations;
 
-  public MutatorImpl(Keyspace keyspace, Serializer<K> keySerializer, BatchSizeHint sizeHint) {
-    this.keyspace = (ExecutingKeyspace) keyspace;
-    this.keySerializer = keySerializer;
-    this.sizeHint = sizeHint;
-  }
+	private ConsistencyLevelPolicy consistencyLevelPolicy;
 
-  public MutatorImpl(Keyspace keyspace, Serializer<K> keySerializer) {
-    this(keyspace, keySerializer, null);
-  }
+	private BatchSizeHint sizeHint;
 
-  public MutatorImpl(Keyspace keyspace) {
-    this(keyspace, TypeInferringSerializer.<K> get());
-  }
+	public MutatorImpl(Keyspace keyspace, Serializer<K> keySerializer, BatchSizeHint sizeHint) {
+		this.keyspace = (ExecutingKeyspace) keyspace;
+		this.keySerializer = keySerializer;
+		this.sizeHint = sizeHint;
+		this.consistencyLevelPolicy = ((ExecutingKeyspace) keyspace).consistencyLevelPolicy;
+	}
 
-  public MutatorImpl(Keyspace keyspace, BatchSizeHint sizeHint) {
-    this(keyspace, TypeInferringSerializer.<K> get(), sizeHint);
-  }
-  
-  // Simple and immediate insertion of a column
-  @Override
-  public <N,V> MutationResult insert(final K key, final String cf, final HColumn<N,V> c) {
-    addInsertion(key, cf, c);
-    return execute();
-  }
+	public MutatorImpl(Keyspace keyspace, Serializer<K> keySerializer) {
+		this(keyspace, keySerializer, null);
+	}
 
-  // overloaded insert-super
-  @Override
-  public <SN,N,V> MutationResult insert(final K key, final String cf,
-      final HSuperColumn<SN,N,V> superColumn) {
-    addInsertion(key, cf, superColumn);
-    return execute();
-  }
+	public MutatorImpl(Keyspace keyspace) {
+		this(keyspace, TypeInferringSerializer.<K> get());
+	}
 
-  @Override
-  public <N> MutationResult delete(final K key, final String cf, final N columnName,
-      final Serializer<N> nameSerializer) {
-    addDeletion(key, cf, columnName, nameSerializer);
-    return execute();
-  }
-  
-  
-  @Override
-  public <N> MutationResult delete(K key, String cf, N columnName,
-      Serializer<N> nameSerializer, long clock) {   
-    addDeletion(key, cf, columnName, nameSerializer, clock);
-    return execute();
-  }
+	public MutatorImpl(Keyspace keyspace, BatchSizeHint sizeHint) {
+		this(keyspace, TypeInferringSerializer.<K> get(), sizeHint);
+	}
 
+	// Simple and immediate insertion of a column
+	@Override
+	public <N, V> MutationResult insert(final K key, final String cf, final HColumn<N, V> c)
+	{
+		addInsertion(key, cf, c);
+		return execute();
+	}
 
-/**
- * Deletes a subcolumn of a supercolumn
- * @param <SN> super column type
- * @param <N> subcolumn type
- */
-  @Override
-  public <SN,N> MutationResult subDelete(final K key, final String cf, final SN supercolumnName,
-      final N columnName, final Serializer<SN> sNameSerializer, final Serializer<N> nameSerializer) {
-    return new MutationResultImpl(keyspace.doExecute(new KeyspaceOperationCallback<Void>() {
-      @Override
-      public Void doInKeyspace(KeyspaceService ks) throws HectorException {
-        ks.remove(keySerializer.toByteBuffer(key), ThriftFactory.createSuperColumnPath(cf,
-            supercolumnName, columnName, sNameSerializer, nameSerializer));
-        return null;
-      }
-    }));
-  }  
-  
-  @Override
-  public <SN> MutationResult superDelete(final K key, final String cf, final SN supercolumnName, 
-      final Serializer<SN> sNameSerializer) {
-    return new MutationResultImpl(keyspace.doExecute(new KeyspaceOperationCallback<Void>() {
-        @Override
-        public Void doInKeyspace(KeyspaceService ks) throws HectorException {
-          // Remove a Super Column.
-          ks.remove(
-              keySerializer.toByteBuffer(key), 
-              ThriftFactory.createSuperColumnPath(cf, supercolumnName, sNameSerializer));
-          return null;
-        }
-      }));
-  }
-  
-  /**
-   * Deletes the columns defined in the HSuperColumn. If there are no HColumns attached,
-   * we delete the whole thing. 
-   * 
-   */
-  public <SN,N,V> Mutator<K> addSubDelete(K key, String cf, HSuperColumn<SN,N,V> sc) {
-    return addSubDelete(key, cf, sc, keyspace.createClock());
-  }
-  
-  public <SN,N,V> Mutator<K> addSubDelete(K key, String cf, HSuperColumn<SN,N,V> sc, long clock) {
-    Deletion d = new Deletion().setTimestamp(clock);
-    if ( sc.getColumns() != null ) {      
-      SlicePredicate pred = new SlicePredicate();
-      for (HColumn<N, V> col : sc.getColumns()) {
-        pred.addToColumn_names(col.getNameSerializer().toByteBuffer(col.getName()));
-      }
-      d.setPredicate(pred);
-    }    
-    d.setSuper_column(sc.getNameByteBuffer());
-    getPendingMutations().addDeletion(key, Arrays.asList(cf), d);        
-    return this;
-  }
-  
-  // schedule an insertion to be executed in batch by the execute method
-  // CAVEAT: a large number of calls with a typo in one of them will leave things in an
-  // indeterminant state if we dont validate against LIVE (but cached of course)
-  // keyspaces and CFs on each add/delete call
-  // also, should throw a typed StatementValidationException or similar perhaps?
-  @Override
-  public <N,V> Mutator<K> addInsertion(K key, String cf, HColumn<N,V> c) {
-    getPendingMutations().addInsertion(key, Arrays.asList(cf),
-        ((HColumnImpl<N, V>) c).toThrift());
-    return this;
-  }
+	// overloaded insert-super
+	@Override
+	public <SN, N, V> MutationResult insert(final K key, final String cf,
+			final HSuperColumn<SN, N, V> superColumn)
+	{
+		addInsertion(key, cf, superColumn);
+		return execute();
+	}
 
-  /**
-   * Schedule an insertion of a supercolumn to be inserted in batch mode by {@link #execute()}
-   */
-  @Override
-  public <SN,N,V> Mutator<K> addInsertion(K key, String cf, HSuperColumn<SN,N,V> sc) {
-    getPendingMutations().addSuperInsertion(key, Arrays.asList(cf),
-        ((HSuperColumnImpl<SN,N,V>) sc).toThrift());
-    return this;
-  }
+	@Override
+	public <N> MutationResult delete(final K key, final String cf, final N columnName,
+			final Serializer<N> nameSerializer)
+	{
+		addDeletion(key, cf, columnName, nameSerializer);
+		return execute();
+	}
 
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  public <N> Mutator<K> addDeletion(K key, String cf, N columnName, Serializer<N> nameSerializer) {
-    addDeletion(key, cf, columnName, nameSerializer, keyspace.createClock());
-    return this;
-  }
-  
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  public <N> Mutator<K> addDeletion(K key, String cf) {
-    addDeletion(key, cf, null, null, keyspace.createClock());
-    return this;
-  }
-  
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  public <N> Mutator<K> addDeletion(K key, String cf, long clock) {
-    addDeletion(key, cf, null, null, clock);
-    return this;
-  }
-  
-  @Override
-  public <N> Mutator<K> addDeletion(Iterable<K> keys, String cf) {
-    return addDeletion(keys, cf, keyspace.createClock());
-  }
-  
-  @Override
-  public <N> Mutator<K> addDeletion(Iterable<K> keys, String cf, long clock) {
-    for (K key : keys) {
-      addDeletion(key, cf, null, null, clock);
-    }
-    return this;
-  }
+	@Override
+	public <N> MutationResult delete(K key, String cf, N columnName, Serializer<N> nameSerializer,
+			long clock)
+	{
+		addDeletion(key, cf, columnName, nameSerializer, clock);
+		return execute();
+	}
 
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  public <N> Mutator<K> addDeletion(K key, String cf, N columnName, Serializer<N> nameSerializer, long clock) {
-    Deletion d;
-    if ( columnName != null ) {
-      SlicePredicate sp = new SlicePredicate();
-      sp.addToColumn_names(nameSerializer.toByteBuffer(columnName));
-      d = new Deletion().setTimestamp(clock).setPredicate(sp);
-    } else { 
-      d = new Deletion().setTimestamp(clock);
-    }
-    getPendingMutations().addDeletion(key, Arrays.asList(cf), d);
-    return this;
-  }
+	/**
+	 * Deletes a subcolumn of a supercolumn
+	 * 
+	 * @param <SN>
+	 *            super column type
+	 * @param <N>
+	 *            subcolumn type
+	 */
+	@Override
+	public <SN, N> MutationResult subDelete(final K key, final String cf, final SN supercolumnName,
+			final N columnName, final Serializer<SN> sNameSerializer,
+			final Serializer<N> nameSerializer)
+	{
+		return new MutationResultImpl(keyspace.doExecute(new KeyspaceOperationCallback<Void>()
+		{
+			@Override
+			public Void doInKeyspace(KeyspaceService ks) throws HectorException
+			{
+				ks.remove(keySerializer.toByteBuffer(key), ThriftFactory.createSuperColumnPath(cf,
+						supercolumnName, columnName, sNameSerializer, nameSerializer));
+				return null;
+			}
+		}));
+	}
 
-  /**
-   * Batch executes all mutations scheduled to this Mutator instance by addInsertion, addDeletion etc.
-   * May throw a HectorException which is a RuntimeException.
-   * @return A MutationResult holds the status.
-   */
-  @Override
-  public MutationResult execute() {
-    if (pendingMutations == null || pendingMutations.isEmpty()) {
-      return new MutationResultImpl(true, 0, null);
-    }
-    final BatchMutation<K> mutations = pendingMutations.makeCopy();
-    pendingMutations = null;
-    return new MutationResultImpl(keyspace.doExecuteOperation(new Operation<Void>(OperationType.WRITE) {
-      @Override
-      public Void execute(Cassandra.Client cassandra) throws Exception {
-        cassandra.batch_mutate(mutations.getMutationMap(),
-          ThriftConverter.consistencyLevel(consistencyLevelPolicy.get(operationType)));
-        return null;
-      }
-    }));
+	@Override
+	public <SN> MutationResult superDelete(final K key, final String cf, final SN supercolumnName,
+			final Serializer<SN> sNameSerializer)
+	{
+		return new MutationResultImpl(keyspace.doExecute(new KeyspaceOperationCallback<Void>()
+		{
+			@Override
+			public Void doInKeyspace(KeyspaceService ks) throws HectorException
+			{
+				// Remove a Super Column.
+				ks.remove(keySerializer.toByteBuffer(key),
+						ThriftFactory.createSuperColumnPath(cf, supercolumnName, sNameSerializer));
+				return null;
+			}
+		}));
+	}
 
-  }
+	/**
+	 * Deletes the columns defined in the HSuperColumn. If there are no HColumns attached, we delete the whole thing.
+	 * 
+	 */
+	public <SN, N, V> Mutator<K> addSubDelete(K key, String cf, HSuperColumn<SN, N, V> sc)
+	{
+		return addSubDelete(key, cf, sc, keyspace.createClock());
+	}
 
-  /**
-   * Discards all pending mutations.
-   */
-  @Override
-  public Mutator<K> discardPendingMutations() {
-    pendingMutations = null;
-    return this;
-  }
+	public <SN, N, V> Mutator<K> addSubDelete(K key, String cf, HSuperColumn<SN, N, V> sc,
+			long clock)
+	{
+		Deletion d = new Deletion().setTimestamp(clock);
+		if (sc.getColumns() != null)
+		{
+			SlicePredicate pred = new SlicePredicate();
+			for (HColumn<N, V> col : sc.getColumns())
+			{
+				pred.addToColumn_names(col.getNameSerializer().toByteBuffer(col.getName()));
+			}
+			d.setPredicate(pred);
+		}
+		d.setSuper_column(sc.getNameByteBuffer());
+		getPendingMutations().addDeletion(key, Arrays.asList(cf), d);
+		return this;
+	}
 
-  @Override
-  public String toString() {
-    return "Mutator(" + keyspace.toString() + ")";
-  }
+	// schedule an insertion to be executed in batch by the execute method
+	// CAVEAT: a large number of calls with a typo in one of them will leave things in an
+	// indeterminant state if we dont validate against LIVE (but cached of course)
+	// keyspaces and CFs on each add/delete call
+	// also, should throw a typed StatementValidationException or similar perhaps?
+	@Override
+	public <N, V> Mutator<K> addInsertion(K key, String cf, HColumn<N, V> c)
+	{
+		getPendingMutations().addInsertion(key, Arrays.asList(cf),
+				((HColumnImpl<N, V>) c).toThrift());
+		return this;
+	}
 
-  @Override
-  public int getPendingMutationCount() {
-    return getPendingMutations().getSize();
-  }
+	/**
+	 * Schedule an insertion of a supercolumn to be inserted in batch mode by {@link #execute()}
+	 */
+	@Override
+	public <SN, N, V> Mutator<K> addInsertion(K key, String cf, HSuperColumn<SN, N, V> sc)
+	{
+		getPendingMutations().addSuperInsertion(key, Arrays.asList(cf),
+				((HSuperColumnImpl<SN, N, V>) sc).toThrift());
+		return this;
+	}
 
-  private BatchMutation<K> getPendingMutations() {
-    if (pendingMutations == null) {
-      pendingMutations = new BatchMutation<K>(keySerializer, sizeHint);
-    }
-    return pendingMutations;
-  }
-  
-  // Counters support.
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public <N> Mutator<K> addDeletion(K key, String cf, N columnName, Serializer<N> nameSerializer)
+	{
+		addDeletion(key, cf, columnName, nameSerializer, keyspace.createClock());
+		return this;
+	}
 
-  @Override
-  public <N> MutationResult insertCounter(final K key, final String cf, final HCounterColumn<N> c) {
-    addCounter(key,cf, c);
-    return execute();
-  }
-  
-  @Override
-  public <N> MutationResult incrementCounter(final K key, final String cf, final N columnName, final long increment) {
-	  return insertCounter(key, cf, new HCounterColumnImpl<N>(columnName, increment, TypeInferringSerializer.<N> get()));
-  }
-  
-  @Override
-  public <N> MutationResult decrementCounter(final K key, final String cf, final N columnName, final long increment) {
-    return incrementCounter(key, cf, columnName, increment * -1L);
-  }
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public <N> Mutator<K> addDeletion(K key, String cf)
+	{
+		addDeletion(key, cf, null, null, keyspace.createClock());
+		return this;
+	}
 
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public <N> Mutator<K> addDeletion(K key, String cf, long clock)
+	{
+		addDeletion(key, cf, null, null, clock);
+		return this;
+	}
 
-  @Override
-  public <SN, N> MutationResult insertCounter(K key, String cf, HCounterSuperColumn<SN, N> superColumn) {
-    addCounter(key, cf, superColumn);
-    return execute();
-  }
+	@Override
+	public <N> Mutator<K> addDeletion(Iterable<K> keys, String cf)
+	{
+		return addDeletion(keys, cf, keyspace.createClock());
+	}
 
+	@Override
+	public <N> Mutator<K> addDeletion(Iterable<K> keys, String cf, long clock)
+	{
+		for (K key : keys)
+		{
+			addDeletion(key, cf, null, null, clock);
+		}
+		return this;
+	}
 
-  @Override
-  public <N> MutationResult deleteCounter(final K key, final String cf, final N counterColumnName, 
-      final Serializer<N> nameSerializer) {
-    addCounterDeletion(key,cf,counterColumnName,nameSerializer);
-    return execute();
-  }
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public <N> Mutator<K> addDeletion(K key, String cf, N columnName, Serializer<N> nameSerializer,
+			long clock)
+	{
+		Deletion d;
+		if (columnName != null)
+		{
+			SlicePredicate sp = new SlicePredicate();
+			sp.addToColumn_names(nameSerializer.toByteBuffer(columnName));
+			d = new Deletion().setTimestamp(clock).setPredicate(sp);
+		}
+		else
+		{
+			d = new Deletion().setTimestamp(clock);
+		}
+		getPendingMutations().addDeletion(key, Arrays.asList(cf), d);
+		return this;
+	}
 
-  @Override
-  public <SN, N> MutationResult subDeleteCounter(final K key, final String cf, final SN supercolumnName, 
-      final N columnName, final Serializer<SN> sNameSerializer, final Serializer<N> nameSerializer) {
-      addCounterSubDeletion(key,cf,
-        new HCounterSuperColumnImpl<SN,N>(sNameSerializer,nameSerializer)
-          .setName(supercolumnName)
-          .addSubCounterColumn(new HCounterColumnImpl<N>(nameSerializer)));
-    return execute();
-  }
+	/**
+	 * Batch executes all mutations scheduled to this Mutator instance by addInsertion, addDeletion etc. May throw a HectorException which is a RuntimeException.
+	 * 
+	 * @return A MutationResult holds the status.
+	 */
+	@Override
+	public MutationResult execute()
+	{
+		if (pendingMutations == null || pendingMutations.isEmpty())
+		{
+			return new MutationResultImpl(true, 0, null);
+		}
+		final BatchMutation<K> mutations = pendingMutations.makeCopy();
+		pendingMutations = null;
+		final HConsistencyLevel consistencyLevel = consistencyLevelPolicy.get(OperationType.WRITE);
+		return new MutationResultImpl(keyspace.doExecuteOperation(new Operation<Void>(
+				OperationType.WRITE)
+		{
+			@Override
+			public Void execute(Cassandra.Client cassandra) throws Exception
+			{
+				cassandra.batch_mutate(mutations.getMutationMap(),
+						ThriftConverter.consistencyLevel(consistencyLevel));
+				return null;
+			}
+		}));
 
-  @Override
-  public <N> Mutator<K> addCounter(K key, String cf, HCounterColumn<N> c) {
-    getPendingMutations().addCounterInsertion(key, Arrays.asList(cf), ((HCounterColumnImpl<N>) c).toThrift());
-    return this;
-  }
+	}
 
-  @Override
-  public <SN, N> Mutator<K> addCounter(K key, String cf, HCounterSuperColumn<SN, N> sc) {
-    getPendingMutations().addSuperCounterInsertion(key, Arrays.asList(cf), 
-        ((HCounterSuperColumnImpl<SN, N>) sc).toThrift());
-    return this;
-  }
+	/**
+	 * Discards all pending mutations.
+	 */
+	@Override
+	public Mutator<K> discardPendingMutations()
+	{
+		pendingMutations = null;
+		return this;
+	}
 
+	@Override
+	public String toString()
+	{
+		return "Mutator(" + keyspace.toString() + ")";
+	}
 
-  @Override
-  public <N> Mutator<K> addCounterDeletion(K key, String cf, N counterColumnName, Serializer<N> nameSerializer) {
-    Deletion d;
-    if ( counterColumnName != null ) {
-      SlicePredicate sp = new SlicePredicate();
-      sp.addToColumn_names(nameSerializer.toByteBuffer(counterColumnName));
-      d = new Deletion().setPredicate(sp);
-    } else { 
-      d = new Deletion();
-    }
-    getPendingMutations().addDeletion(key, Arrays.asList(cf), d);
-    return this;
-  }
+	@Override
+	public int getPendingMutationCount()
+	{
+		return getPendingMutations().getSize();
+	}
 
-  @Override
-  public <N> Mutator<K> addCounterDeletion(K key, String cf) {    
-    getPendingMutations().addDeletion(key, Arrays.asList(cf), new Deletion());
-    return this;
-  }
+	private BatchMutation<K> getPendingMutations()
+	{
+		if (pendingMutations == null)
+		{
+			pendingMutations = new BatchMutation<K>(keySerializer, sizeHint);
+		}
+		return pendingMutations;
+	}
 
-  @Override
-  public <SN, N> Mutator<K> addCounterSubDeletion(K key, String cf, HCounterSuperColumn<SN, N> sc) {
-    Deletion d = new Deletion();
-    if ( sc.getColumns() != null ) {      
-      SlicePredicate pred = new SlicePredicate();
-      for (HCounterColumn<N> col : sc.getColumns()) {
-        pred.addToColumn_names(col.getNameSerializer().toByteBuffer(col.getName()));
-      }
-      d.setPredicate(pred);
-    }    
-    d.setSuper_column(sc.getNameByteBuffer());
-    getPendingMutations().addDeletion(key, Arrays.asList(cf), d);
-    return this;
-  }
+	// Counters support.
 
-  @Override
-  public <SN, N> Mutator<K> addSubDelete(K key, String cf, SN sColumnName,
-      N columnName, Serializer<SN> sNameSerializer, Serializer<N> nameSerializer) {
-    return addSubDelete(key, cf, sColumnName, columnName, sNameSerializer, nameSerializer, keyspace.createClock());
-  }
-  
-  @Override
-  public <SN, N> Mutator<K> addSubDelete(K key, String cf, SN sColumnName,
-      N columnName, Serializer<SN> sNameSerializer, Serializer<N> nameSerializer, long clock) {
-    Deletion d = new Deletion().setTimestamp(clock);            
-    SlicePredicate predicate = new SlicePredicate();
-    predicate.addToColumn_names(nameSerializer.toByteBuffer(columnName));
-    d.setPredicate(predicate);
-    d.setSuper_column(sNameSerializer.toByteBuffer(sColumnName));
-    getPendingMutations().addDeletion(key, Arrays.asList(cf), d);
-    return this;
-  }
+	@Override
+	public <N> MutationResult insertCounter(final K key, final String cf, final HCounterColumn<N> c)
+	{
+		addCounter(key, cf, c);
+		return execute();
+	}
 
+	@Override
+	public <N> MutationResult incrementCounter(final K key, final String cf, final N columnName,
+			final long increment)
+	{
+		return insertCounter(key, cf, new HCounterColumnImpl<N>(columnName, increment,
+				TypeInferringSerializer.<N> get()));
+	}
 
-  
-  @Override
-  public <SN> Mutator<K> addSuperDelete(K key, String cf, SN sColumnName,
-      Serializer<SN> sNameSerializer) {    
-    Deletion d = new Deletion().setTimestamp(keyspace.createClock());            
-    d.setSuper_column(sNameSerializer.toByteBuffer(sColumnName));
-    getPendingMutations().addDeletion(key, Arrays.asList(cf), d);    
+	@Override
+	public <N> MutationResult decrementCounter(final K key, final String cf, final N columnName,
+			final long increment)
+	{
+		return incrementCounter(key, cf, columnName, increment * -1L);
+	}
 
-    return this;
+	@Override
+	public <SN, N> MutationResult insertCounter(K key, String cf,
+			HCounterSuperColumn<SN, N> superColumn)
+	{
+		addCounter(key, cf, superColumn);
+		return execute();
+	}
 
-  }
+	@Override
+	public <N> MutationResult deleteCounter(final K key, final String cf,
+			final N counterColumnName, final Serializer<N> nameSerializer)
+	{
+		addCounterDeletion(key, cf, counterColumnName, nameSerializer);
+		return execute();
+	}
+
+	@Override
+	public <SN, N> MutationResult subDeleteCounter(final K key, final String cf,
+			final SN supercolumnName, final N columnName, final Serializer<SN> sNameSerializer,
+			final Serializer<N> nameSerializer)
+	{
+		addCounterSubDeletion(
+				key,
+				cf,
+				new HCounterSuperColumnImpl<SN, N>(sNameSerializer, nameSerializer).setName(
+						supercolumnName).addSubCounterColumn(
+						new HCounterColumnImpl<N>(nameSerializer)));
+		return execute();
+	}
+
+	@Override
+	public <N> Mutator<K> addCounter(K key, String cf, HCounterColumn<N> c)
+	{
+		getPendingMutations().addCounterInsertion(key, Arrays.asList(cf),
+				((HCounterColumnImpl<N>) c).toThrift());
+		return this;
+	}
+
+	@Override
+	public <SN, N> Mutator<K> addCounter(K key, String cf, HCounterSuperColumn<SN, N> sc)
+	{
+		getPendingMutations().addSuperCounterInsertion(key, Arrays.asList(cf),
+				((HCounterSuperColumnImpl<SN, N>) sc).toThrift());
+		return this;
+	}
+
+	@Override
+	public <N> Mutator<K> addCounterDeletion(K key, String cf, N counterColumnName,
+			Serializer<N> nameSerializer)
+	{
+		Deletion d;
+		if (counterColumnName != null)
+		{
+			SlicePredicate sp = new SlicePredicate();
+			sp.addToColumn_names(nameSerializer.toByteBuffer(counterColumnName));
+			d = new Deletion().setPredicate(sp);
+		}
+		else
+		{
+			d = new Deletion();
+		}
+		getPendingMutations().addDeletion(key, Arrays.asList(cf), d);
+		return this;
+	}
+
+	@Override
+	public <N> Mutator<K> addCounterDeletion(K key, String cf)
+	{
+		getPendingMutations().addDeletion(key, Arrays.asList(cf), new Deletion());
+		return this;
+	}
+
+	@Override
+	public <SN, N> Mutator<K> addCounterSubDeletion(K key, String cf, HCounterSuperColumn<SN, N> sc)
+	{
+		Deletion d = new Deletion();
+		if (sc.getColumns() != null)
+		{
+			SlicePredicate pred = new SlicePredicate();
+			for (HCounterColumn<N> col : sc.getColumns())
+			{
+				pred.addToColumn_names(col.getNameSerializer().toByteBuffer(col.getName()));
+			}
+			d.setPredicate(pred);
+		}
+		d.setSuper_column(sc.getNameByteBuffer());
+		getPendingMutations().addDeletion(key, Arrays.asList(cf), d);
+		return this;
+	}
+
+	@Override
+	public <SN, N> Mutator<K> addSubDelete(K key, String cf, SN sColumnName, N columnName,
+			Serializer<SN> sNameSerializer, Serializer<N> nameSerializer)
+	{
+		return addSubDelete(key, cf, sColumnName, columnName, sNameSerializer, nameSerializer,
+				keyspace.createClock());
+	}
+
+	@Override
+	public <SN, N> Mutator<K> addSubDelete(K key, String cf, SN sColumnName, N columnName,
+			Serializer<SN> sNameSerializer, Serializer<N> nameSerializer, long clock)
+	{
+		Deletion d = new Deletion().setTimestamp(clock);
+		SlicePredicate predicate = new SlicePredicate();
+		predicate.addToColumn_names(nameSerializer.toByteBuffer(columnName));
+		d.setPredicate(predicate);
+		d.setSuper_column(sNameSerializer.toByteBuffer(sColumnName));
+		getPendingMutations().addDeletion(key, Arrays.asList(cf), d);
+		return this;
+	}
+
+	@Override
+	public <SN> Mutator<K> addSuperDelete(K key, String cf, SN sColumnName,
+			Serializer<SN> sNameSerializer)
+	{
+		Deletion d = new Deletion().setTimestamp(keyspace.createClock());
+		d.setSuper_column(sNameSerializer.toByteBuffer(sColumnName));
+		getPendingMutations().addDeletion(key, Arrays.asList(cf), d);
+
+		return this;
+
+	}
 
 }

--- a/core/src/main/java/me/prettyprint/cassandra/service/HColumnFamilyImpl.java
+++ b/core/src/main/java/me/prettyprint/cassandra/service/HColumnFamilyImpl.java
@@ -39,321 +39,385 @@ import org.apache.cassandra.thrift.ColumnParent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class HColumnFamilyImpl<K,N> implements HColumnFamily<K, N> {
+public class HColumnFamilyImpl<K, N> implements HColumnFamily<K, N>
+{
 
-  private final Logger queryLogger = LoggerFactory.getLogger("HColumnFamilyLogger");
-  private final Logger log = LoggerFactory.getLogger(HColumnFamily.class);
-  
-  private final ExecutingKeyspace keyspace;
-  private final String columnFamilyName;
-  private List<K> _keys;
-  private HSlicePredicate<N> activeSlicePredicate;
-  private HSlicePredicate<N> lastAppliedPredicate;
-  private Serializer<K> keySerializer;
-  private Serializer<N> columnNameSerializer;
-  private ConfigurableConsistencyLevel consistencyLevelPolicy;
-  private Map<N, HColumn<N,ByteBuffer>> columns;
-  private ColumnParent columnParent;
-  private ExceptionsTranslator exceptionsTranslator;
-  private boolean hasValues;
-  // TODO consider a bounds on this
-  private Set<N> columnNames;
-  private int rowIndex = 0;
-  private Map<ByteBuffer, List<ColumnOrSuperColumn>> rows;
-  private CassandraHost lastHostUsed;
-  private long lastExecutionTime;
-  
+	private final Logger queryLogger = LoggerFactory.getLogger("HColumnFamilyLogger");
+	private final Logger log = LoggerFactory.getLogger(HColumnFamily.class);
 
-  public HColumnFamilyImpl(Keyspace keyspace, String columnFamilyName, Serializer<K> keySerializer, Serializer<N> columnNameSerializer) {
-    this.keyspace = (ExecutingKeyspace)keyspace;
-    this.columnFamilyName = columnFamilyName;
-    this._keys = new ArrayList<K>();
-    this.keySerializer = keySerializer;
-    this.columnNameSerializer = columnNameSerializer;
-    this.activeSlicePredicate = new HSlicePredicate<N>(columnNameSerializer);
-    this.columnParent = new ColumnParent(columnFamilyName);
-    exceptionsTranslator = new ExceptionsTranslatorImpl();
-    this.consistencyLevelPolicy = new ConfigurableConsistencyLevel();
-  }
-  
-  @Override
-  public HColumnFamily<K, N> addKey(K key) {
-    _keys.add(key);
-    return this;
-  }
+	private final ExecutingKeyspace keyspace;
+	private final String columnFamilyName;
+	private List<K> _keys;
+	private HSlicePredicate<N> activeSlicePredicate;
+	private HSlicePredicate<N> lastAppliedPredicate;
+	private Serializer<K> keySerializer;
+	private Serializer<N> columnNameSerializer;
+	private ConfigurableConsistencyLevel consistencyLevelPolicy;
+	private Map<N, HColumn<N, ByteBuffer>> columns;
+	private ColumnParent columnParent;
+	private ExceptionsTranslator exceptionsTranslator;
+	private boolean hasValues;
+	// TODO consider a bounds on this
+	private Set<N> columnNames;
+	private int rowIndex = 0;
+	private Map<ByteBuffer, List<ColumnOrSuperColumn>> rows;
+	private CassandraHost lastHostUsed;
+	private long lastExecutionTime;
 
-  @Override
-  public HColumnFamily<K, N> addKeys(Collection<K> keys) {
-    _keys.addAll(keys);
-    return this;
-  }  
-  
-  
+	public HColumnFamilyImpl(Keyspace keyspace, String columnFamilyName,
+			Serializer<K> keySerializer, Serializer<N> columnNameSerializer)
+	{
+		this.keyspace = (ExecutingKeyspace) keyspace;
+		this.columnFamilyName = columnFamilyName;
+		this._keys = new ArrayList<K>();
+		this.keySerializer = keySerializer;
+		this.columnNameSerializer = columnNameSerializer;
+		this.activeSlicePredicate = new HSlicePredicate<N>(columnNameSerializer);
+		this.columnParent = new ColumnParent(columnFamilyName);
+		exceptionsTranslator = new ExceptionsTranslatorImpl();
+		this.consistencyLevelPolicy = new ConfigurableConsistencyLevel();
+	}
 
-  @Override
-  public HColumnFamily<K, N> removeKeys() {
-    _keys.clear();
-    return this;
-  }
+	@Override
+	public HColumnFamily<K, N> addKey(K key)
+	{
+		_keys.add(key);
+		return this;
+	}
 
-  @Override
-  public HColumnFamily<K, N> setCount(int count) {
-    activeSlicePredicate.setCount(count);
-    return this;
-  }
+	@Override
+	public HColumnFamily<K, N> addKeys(Collection<K> keys)
+	{
+		_keys.addAll(keys);
+		return this;
+	}
 
-  @Override
-  public HColumnFamily<K, N> setFinish(N name) {
-    activeSlicePredicate.setEndOn(name);
-    return this;
-  }
+	@Override
+	public HColumnFamily<K, N> removeKeys()
+	{
+		_keys.clear();
+		return this;
+	}
 
-  @Override
-  public HColumnFamily<K, N> setReversed(boolean reversed) {
-    activeSlicePredicate.setReversed(reversed);
-    return this;
-  }
+	@Override
+	public HColumnFamily<K, N> setCount(int count)
+	{
+		activeSlicePredicate.setCount(count);
+		return this;
+	}
 
-  @Override
-  public HColumnFamily<K, N> setStart(N name) {
-    activeSlicePredicate.setStartOn(name);
-    return this;
-  }   
+	@Override
+	public HColumnFamily<K, N> setFinish(N name)
+	{
+		activeSlicePredicate.setEndOn(name);
+		return this;
+	}
 
-  @Override
-  public HColumnFamily<K, N> addColumnName(N columnName) {
-    activeSlicePredicate.addColumnName(columnName);
-    return this;
-  }
+	@Override
+	public HColumnFamily<K, N> setReversed(boolean reversed)
+	{
+		activeSlicePredicate.setReversed(reversed);
+		return this;
+	}
 
-  @Override
-  public HColumnFamily<K, N> setColumnNames(Collection<N> columnNames) {
-    activeSlicePredicate.setColumnNames(columnNames);
-    return null;
-  }
+	@Override
+	public HColumnFamily<K, N> setStart(N name)
+	{
+		activeSlicePredicate.setStartOn(name);
+		return this;
+	}
 
-  @Override
-  public HColumn<N, ?> getColumn(N name) {
-    // TODO Auto-generated method stub
-    return null;
-  }
+	@Override
+	public HColumnFamily<K, N> addColumnName(N columnName)
+	{
+		activeSlicePredicate.addColumnName(columnName);
+		return this;
+	}
 
-  @Override
-  public Collection<HColumn<N, ByteBuffer>> getColumns() {
-    if ( columns == null )
-      columns = new HashMap<N, HColumn<N,ByteBuffer>>();      
-    
-    if ( !hasValues )
-      doExecuteSlice();
-    
-    return columns.values();
-  }
+	@Override
+	public HColumnFamily<K, N> setColumnNames(Collection<N> columnNames)
+	{
+		activeSlicePredicate.setColumnNames(columnNames);
+		return null;
+	}
 
-  
-  
-  @Override
-  public HColumnFamily<K, N> clear() {
-    for (HColumn<N,ByteBuffer> col : columns.values() ) {
-      // could probably do something fancier hear calling clear() on the underlying BB
-      col.clear();
-    }
-    hasValues = false;
-    return this;
-  }
+	@Override
+	public HColumn<N, ?> getColumn(N name)
+	{
+		// TODO Auto-generated method stub
+		return null;
+	}
 
-  @Override
-  public Date getDate(N name) {
-    return extractColumnValue(name, DateSerializer.get());
-  }
+	@Override
+	public Collection<HColumn<N, ByteBuffer>> getColumns()
+	{
+		if (columns == null)
+			columns = new HashMap<N, HColumn<N, ByteBuffer>>();
 
-  @Override
-  public double getDouble(N name) {
-    return extractColumnValue(name, DoubleSerializer.get());
-  }
+		if (!hasValues)
+			doExecuteSlice();
 
-  @Override
-  public int getInt(N name) {    
-    return extractColumnValue(name, IntegerSerializer.get());
-  }
+		return columns.values();
+	}
 
-  @Override
-  public long getLong(N name) {
-    return extractColumnValue(name, LongSerializer.get());
-  }
+	@Override
+	public HColumnFamily<K, N> clear()
+	{
+		for (HColumn<N, ByteBuffer> col : columns.values())
+		{
+			// could probably do something fancier hear calling clear() on the underlying BB
+			col.clear();
+		}
+		hasValues = false;
+		return this;
+	}
 
-  @Override
-  public String getString(N name) {    
-    return extractColumnValue(name, StringSerializer.get());
-  }
+	@Override
+	public Date getDate(N name)
+	{
+		return extractColumnValue(name, DateSerializer.get());
+	}
 
-  @Override
-  public UUID getUUID(N name) {
-    return extractColumnValue(name, UUIDSerializer.get());
-  }
+	@Override
+	public double getDouble(N name)
+	{
+		return extractColumnValue(name, DoubleSerializer.get());
+	}
 
-  @Override
-  public HColumnFamily<K, N> next() {
-    if ( !hasNext() ) {
-      throw new NoSuchElementException("No more rows left on this HColumnFamily");
-    }
-    rowIndex++;
-    K key = _keys.get(rowIndex);
-    applyToRow(key, rows.get(keySerializer.toByteBuffer(key)));
-    return this;
-  }
-  
-  @Override
-  public boolean hasNext() {
-    return rowIndex < rows.size() - 1 ;
-  }
+	@Override
+	public int getInt(N name)
+	{
+		return extractColumnValue(name, IntegerSerializer.get());
+	}
 
-  @Override
-  public void remove() {
-    K key = _keys.remove(rowIndex);
-    rows.remove(key);
-  }
+	@Override
+	public long getLong(N name)
+	{
+		return extractColumnValue(name, LongSerializer.get());
+	}
 
-  /**
-   * Extract a value for the specified name and serializer
-   */
-  @Override
-  public <V> V getValue(N name, Serializer<V> valueSerializer) {    
-    return extractColumnValue(name, valueSerializer);
-  }
+	@Override
+	public String getString(N name)
+	{
+		return extractColumnValue(name, StringSerializer.get());
+	}
 
-  @Override
-  public HColumnFamily<K, N> setReadConsistencyLevel(HConsistencyLevel readLevel) {
-    consistencyLevelPolicy.setDefaultReadConsistencyLevel(readLevel);
-    return this;
-  }
+	@Override
+	public UUID getUUID(N name)
+	{
+		return extractColumnValue(name, UUIDSerializer.get());
+	}
 
-  @Override
-  public HColumnFamily<K, N> setWriteConsistencyLevel(HConsistencyLevel writeLevel) {
-    consistencyLevelPolicy.setDefaultWriteConsistencyLevel(writeLevel);
-    return this;
-  }
+	@Override
+	public HColumnFamily<K, N> next()
+	{
+		if (!hasNext())
+		{
+			throw new NoSuchElementException("No more rows left on this HColumnFamily");
+		}
+		rowIndex++;
+		K key = _keys.get(rowIndex);
+		applyToRow(key, rows.get(keySerializer.toByteBuffer(key)));
+		return this;
+	}
 
-  
-  
-  @Override
-  public long getExecutionTimeMicro() {  
-    return lastExecutionTime / 1000;
-  }
+	@Override
+	public boolean hasNext()
+	{
+		return rowIndex < rows.size() - 1;
+	}
 
-  @Override
-  public CassandraHost getHostUsed() {
-    return lastHostUsed;
-  }
+	@Override
+	public void remove()
+	{
+		K key = _keys.remove(rowIndex);
+		rows.remove(key);
+	}
 
-  private <V> V extractColumnValue(N columnName, Serializer<V> valueSerializer) {
-    maybeExecuteSlice(columnName);        
-    return columns.get(columnName) != null && columns.get(columnName).getValue() != null ? valueSerializer.fromByteBuffer(columns.get(columnName).getValue()) : null;    
-  }
-  
-  private void maybeExecuteSlice(N columnName) {
-    if ( columnNames == null ) {
-      columnNames = new HashSet<N>();
-    }
-    if ( columns == null ) {
-      columns = new HashMap<N, HColumn<N,ByteBuffer>>();
-    }
-    if ( columns.get(columnName) == null ) {
-      columnNames.add(columnName);
-      activeSlicePredicate.setColumnNames(columnNames);
-      if ( _keys.size() == 1 ) {
-        doExecuteSlice();
-      } else {
-        doExecuteMultigetSlice();
-      }      
-    }    
-  }
-  
-  
-  private void applyToRow(K key, List<ColumnOrSuperColumn> cosclist) {
-    HColumn<N, ByteBuffer> column;
-    N colName;
-    for (Iterator<ColumnOrSuperColumn> iterator = cosclist.iterator(); iterator.hasNext();) {
-      ColumnOrSuperColumn cosc = iterator.next();            
+	/**
+	 * Extract a value for the specified name and serializer
+	 */
+	@Override
+	public <V> V getValue(N name, Serializer<V> valueSerializer)
+	{
+		return extractColumnValue(name, valueSerializer);
+	}
 
-      colName = columnNameSerializer.fromByteBuffer(cosc.getColumn().name.duplicate());
-      column = columns.get(colName);
-      
-      if ( column == null ) {
-        column = new HColumnImpl<N, ByteBuffer>(cosc.getColumn(), columnNameSerializer, ByteBufferSerializer.get());
-      } else {
-        ((HColumnImpl<N, ByteBuffer>)column).apply(cosc.getColumn());
-      }
-      columns.put(colName, column); 
-      iterator.remove();
-    }
-  }
-  
-  private void applyResultStatus(long execTime, CassandraHost cassandraHost) {
-    lastExecutionTime = execTime;
-    lastHostUsed = cassandraHost;
-  }
-  
-  private void doExecuteSlice() {
-    keyspace.doExecuteOperation(new Operation<Column>(OperationType.READ) {
-      @Override
-      public Column execute(Cassandra.Client cassandra) throws HectorException {
-        
-        try {          
-          if ( queryLogger.isDebugEnabled() ) {
-            queryLogger.debug("---------\nColumnFamily: {} slicePredicate: {}", columnFamilyName, activeSlicePredicate.toString());
-          }
+	@Override
+	public HColumnFamily<K, N> setReadConsistencyLevel(HConsistencyLevel readLevel)
+	{
+		consistencyLevelPolicy.setDefaultReadConsistencyLevel(readLevel);
+		return this;
+	}
 
-          K key = _keys.iterator().next();
-          List<ColumnOrSuperColumn> cosclist = cassandra.get_slice(keySerializer.toByteBuffer(key), columnParent,
-            activeSlicePredicate.toThrift(), 
-            ThriftConverter.consistencyLevel(consistencyLevelPolicy.get(operationType)));
-          applyResultStatus(execTime, getCassandraHost());
-          applyToRow(key, cosclist);
-          if ( queryLogger.isDebugEnabled() ) {
-            queryLogger.debug("Execution took {} microseconds on host {}\n----------", lastExecutionTime, lastHostUsed);
-          }
-        } catch (Exception e) {
-          throw exceptionsTranslator.translate(e);
-        }
-        hasValues = true;
+	@Override
+	public HColumnFamily<K, N> setWriteConsistencyLevel(HConsistencyLevel writeLevel)
+	{
+		consistencyLevelPolicy.setDefaultWriteConsistencyLevel(writeLevel);
+		return this;
+	}
 
-        return null;
-      }
-    });
-  }
-  
+	@Override
+	public long getExecutionTimeMicro()
+	{
+		return lastExecutionTime / 1000;
+	}
 
-  private void doExecuteMultigetSlice() {
-    keyspace.doExecuteOperation(new Operation<Column>(OperationType.READ) {
-      @Override
-      public Column execute(Cassandra.Client cassandra) throws HectorException {
-        try {          
-          if ( queryLogger.isDebugEnabled() ) {
-            queryLogger.debug("---------\nColumnFamily multiget: {} slicePredicate: {}", columnFamilyName, activeSlicePredicate.toString());
-          }
+	@Override
+	public CassandraHost getHostUsed()
+	{
+		return lastHostUsed;
+	}
 
-          rows = cassandra.multiget_slice(keySerializer.toBytesList(_keys), columnParent, activeSlicePredicate.toThrift(), 
-              ThriftConverter.consistencyLevel(consistencyLevelPolicy.get(operationType)));
+	private <V> V extractColumnValue(N columnName, Serializer<V> valueSerializer)
+	{
+		maybeExecuteSlice(columnName);
+		return columns.get(columnName) != null && columns.get(columnName).getValue() != null ? valueSerializer
+				.fromByteBuffer(columns.get(columnName).getValue()) : null;
+	}
 
-          applyResultStatus(execTime, getCassandraHost());
-          
-          if ( queryLogger.isDebugEnabled() ) {
-            queryLogger.debug("Execution took {} microseconds on host {}\n----------", lastExecutionTime, lastHostUsed);
-          }
-        } catch (Exception e) {
-          throw exceptionsTranslator.translate(e);
-        }
-        hasValues = true;
+	private void maybeExecuteSlice(N columnName)
+	{
+		if (columnNames == null)
+		{
+			columnNames = new HashSet<N>();
+		}
+		if (columns == null)
+		{
+			columns = new HashMap<N, HColumn<N, ByteBuffer>>();
+		}
+		if (columns.get(columnName) == null)
+		{
+			columnNames.add(columnName);
+			activeSlicePredicate.setColumnNames(columnNames);
+			if (_keys.size() == 1)
+			{
+				doExecuteSlice();
+			}
+			else
+			{
+				doExecuteMultigetSlice();
+			}
+		}
+	}
 
-        return null;
-      }
-    });
-    applyToRow(_keys.get(0), rows.get(keySerializer.toByteBuffer(_keys.get(0))));
-  }
+	private void applyToRow(K key, List<ColumnOrSuperColumn> cosclist)
+	{
+		HColumn<N, ByteBuffer> column;
+		N colName;
+		for (Iterator<ColumnOrSuperColumn> iterator = cosclist.iterator(); iterator.hasNext();)
+		{
+			ColumnOrSuperColumn cosc = iterator.next();
 
-  @Override
-  public long getExecutionTimeNano() {
-    return lastExecutionTime;
-  }
+			colName = columnNameSerializer.fromByteBuffer(cosc.getColumn().name.duplicate());
+			column = columns.get(colName);
+
+			if (column == null)
+			{
+				column = new HColumnImpl<N, ByteBuffer>(cosc.getColumn(), columnNameSerializer,
+						ByteBufferSerializer.get());
+			}
+			else
+			{
+				((HColumnImpl<N, ByteBuffer>) column).apply(cosc.getColumn());
+			}
+			columns.put(colName, column);
+			iterator.remove();
+		}
+	}
+
+	private void applyResultStatus(long execTime, CassandraHost cassandraHost)
+	{
+		lastExecutionTime = execTime;
+		lastHostUsed = cassandraHost;
+	}
+
+	private void doExecuteSlice()
+	{
+		final HConsistencyLevel consistencyLevel = consistencyLevelPolicy.get(OperationType.READ);
+		keyspace.doExecuteOperation(new Operation<Column>(OperationType.READ)
+		{
+			@Override
+			public Column execute(Cassandra.Client cassandra) throws HectorException
+			{
+
+				try
+				{
+					if (queryLogger.isDebugEnabled())
+					{
+						queryLogger.debug("---------\nColumnFamily: {} slicePredicate: {}",
+								columnFamilyName, activeSlicePredicate.toString());
+					}
+
+					K key = _keys.iterator().next();
+					List<ColumnOrSuperColumn> cosclist = cassandra.get_slice(
+							keySerializer.toByteBuffer(key), columnParent,
+							activeSlicePredicate.toThrift(),
+							ThriftConverter.consistencyLevel(consistencyLevel));
+					applyResultStatus(execTime, getCassandraHost());
+					applyToRow(key, cosclist);
+					if (queryLogger.isDebugEnabled())
+					{
+						queryLogger.debug("Execution took {} microseconds on host {}\n----------",
+								lastExecutionTime, lastHostUsed);
+					}
+				}
+				catch (Exception e)
+				{
+					throw exceptionsTranslator.translate(e);
+				}
+				hasValues = true;
+
+				return null;
+			}
+		});
+	}
+
+	private void doExecuteMultigetSlice()
+	{
+		final HConsistencyLevel consistencyLevel = consistencyLevelPolicy.get(OperationType.READ);
+		keyspace.doExecuteOperation(new Operation<Column>(OperationType.READ)
+		{
+			@Override
+			public Column execute(Cassandra.Client cassandra) throws HectorException
+			{
+				try
+				{
+					if (queryLogger.isDebugEnabled())
+					{
+						queryLogger.debug(
+								"---------\nColumnFamily multiget: {} slicePredicate: {}",
+								columnFamilyName, activeSlicePredicate.toString());
+					}
+
+					rows = cassandra.multiget_slice(keySerializer.toBytesList(_keys), columnParent,
+							activeSlicePredicate.toThrift(),
+							ThriftConverter.consistencyLevel(consistencyLevel));
+
+					applyResultStatus(execTime, getCassandraHost());
+
+					if (queryLogger.isDebugEnabled())
+					{
+						queryLogger.debug("Execution took {} microseconds on host {}\n----------",
+								lastExecutionTime, lastHostUsed);
+					}
+				}
+				catch (Exception e)
+				{
+					throw exceptionsTranslator.translate(e);
+				}
+				hasValues = true;
+
+				return null;
+			}
+		});
+		applyToRow(_keys.get(0), rows.get(keySerializer.toByteBuffer(_keys.get(0))));
+	}
+
+	@Override
+	public long getExecutionTimeNano()
+	{
+		return lastExecutionTime;
+	}
 
 }

--- a/core/src/main/java/me/prettyprint/cassandra/service/template/ThriftColumnFamilyTemplate.java
+++ b/core/src/main/java/me/prettyprint/cassandra/service/template/ThriftColumnFamilyTemplate.java
@@ -12,6 +12,7 @@ import me.prettyprint.cassandra.model.HSlicePredicate;
 import me.prettyprint.cassandra.model.thrift.ThriftConverter;
 import me.prettyprint.cassandra.service.Operation;
 import me.prettyprint.cassandra.service.OperationType;
+import me.prettyprint.hector.api.HConsistencyLevel;
 import me.prettyprint.hector.api.Keyspace;
 import me.prettyprint.hector.api.Serializer;
 import me.prettyprint.hector.api.exceptions.HectorException;
@@ -24,130 +25,183 @@ import org.apache.cassandra.thrift.KeySlice;
 import com.google.common.collect.Iterators;
 
 /**
- * Thrift specific implementation of {@link ColumnFamilyTemplate} 
+ * Thrift specific implementation of {@link ColumnFamilyTemplate}
+ * 
  * @author nate
- *
+ * 
  * @param <K>
  * @param <N>
  */
-public class ThriftColumnFamilyTemplate<K, N> extends ColumnFamilyTemplate<K, N> {
-  
-  
-  public ThriftColumnFamilyTemplate(Keyspace keyspace, String columnFamily,
-      Serializer<K> keySerializer, Serializer<N> topSerializer) {
-    super(keyspace, columnFamily, keySerializer, topSerializer);
-  }
+public class ThriftColumnFamilyTemplate<K, N> extends ColumnFamilyTemplate<K, N>
+{
 
-  public <T> T doExecuteSlice(K key, HSlicePredicate<N> predicate, ColumnFamilyRowMapper<K, N, T> mapper) {
-    return mapper.mapRow(doExecuteSlice(key,predicate));
-  }
+	public ThriftColumnFamilyTemplate(Keyspace keyspace, String columnFamily,
+			Serializer<K> keySerializer, Serializer<N> topSerializer)
+	{
+		super(keyspace, columnFamily, keySerializer, topSerializer);
+	}
 
-  public ColumnFamilyResult<K, N> doExecuteSlice(final K key, final HSlicePredicate<N> workingSlicePredicate) {    
-    return new ColumnFamilyResultWrapper<K, N>(keySerializer, topSerializer, 
-        sliceInternal(key, workingSlicePredicate));
-  }
+	public <T> T doExecuteSlice(K key, HSlicePredicate<N> predicate,
+			ColumnFamilyRowMapper<K, N, T> mapper)
+	{
+		return mapper.mapRow(doExecuteSlice(key, predicate));
+	}
 
-  public ColumnFamilyResult<K, N> doExecuteMultigetSlice(final Iterable<K> keys, final HSlicePredicate<N> workingSlicePredicate) {    
-    return new ColumnFamilyResultWrapper<K, N>(keySerializer, topSerializer, 
-        multigetSliceInternal(keys, workingSlicePredicate));
-  }
+	public ColumnFamilyResult<K, N> doExecuteSlice(final K key,
+			final HSlicePredicate<N> workingSlicePredicate)
+	{
+		return new ColumnFamilyResultWrapper<K, N>(keySerializer, topSerializer, sliceInternal(key,
+				workingSlicePredicate));
+	}
 
-  public <V> MappedColumnFamilyResult<K, N, V> doExecuteMultigetSlice(final Iterable<K> keys, 
-      final HSlicePredicate<N> workingSlicePredicate,
-      final ColumnFamilyRowMapper<K, N, V> mapper) {    
-    return new MappedColumnFamilyResultWrapper<K,N,V>(keySerializer, topSerializer, 
-        multigetSliceInternal(keys, workingSlicePredicate), mapper);    
-  }
+	public ColumnFamilyResult<K, N> doExecuteMultigetSlice(final Iterable<K> keys,
+			final HSlicePredicate<N> workingSlicePredicate)
+	{
+		return new ColumnFamilyResultWrapper<K, N>(keySerializer, topSerializer,
+				multigetSliceInternal(keys, workingSlicePredicate));
+	}
 
-  protected <V> ColumnFamilyResult<K, N> doExecuteIndexedSlices(final IndexedSlicesPredicate<K, N, V> predicate) {
-    return new ColumnFamilyResultWrapper<K, N>(keySerializer, topSerializer,
-        indexedSlicesInternal(predicate, activeSlicePredicate));
-  }
+	public <V> MappedColumnFamilyResult<K, N, V> doExecuteMultigetSlice(final Iterable<K> keys,
+			final HSlicePredicate<N> workingSlicePredicate,
+			final ColumnFamilyRowMapper<K, N, V> mapper)
+	{
+		return new MappedColumnFamilyResultWrapper<K, N, V>(keySerializer, topSerializer,
+				multigetSliceInternal(keys, workingSlicePredicate), mapper);
+	}
 
-  protected <V> ColumnFamilyResult<K, N> doExecuteIndexedSlices(IndexedSlicesPredicate<K, N, V> predicate,
-      HSlicePredicate<N> slicePredicate) {
-    return new ColumnFamilyResultWrapper<K, N>(keySerializer, topSerializer,
-        indexedSlicesInternal(predicate, slicePredicate));
-  }
+	protected <V> ColumnFamilyResult<K, N> doExecuteIndexedSlices(
+			final IndexedSlicesPredicate<K, N, V> predicate)
+	{
+		return new ColumnFamilyResultWrapper<K, N>(keySerializer, topSerializer,
+				indexedSlicesInternal(predicate, activeSlicePredicate));
+	}
 
-  protected <R,V> MappedColumnFamilyResult<K, N, R> doExecuteIndexedSlices(
-      IndexedSlicesPredicate<K, N, V> predicate,
-      ColumnFamilyRowMapper<K, N, R> mapper) {
-    return new MappedColumnFamilyResultWrapper<K,N,R>(keySerializer, topSerializer, 
-        indexedSlicesInternal(predicate, activeSlicePredicate), mapper);
-  }
+	protected <V> ColumnFamilyResult<K, N> doExecuteIndexedSlices(
+			IndexedSlicesPredicate<K, N, V> predicate, HSlicePredicate<N> slicePredicate)
+	{
+		return new ColumnFamilyResultWrapper<K, N>(keySerializer, topSerializer,
+				indexedSlicesInternal(predicate, slicePredicate));
+	}
 
-  protected <R, V> MappedColumnFamilyResult<K, N, R> doExecuteIndexedSlices(IndexedSlicesPredicate<K, N, V> predicate,
-      HSlicePredicate<N> slicePredicate, ColumnFamilyRowMapper<K, N, R> mapper) {
-    return new MappedColumnFamilyResultWrapper<K,N,R>(keySerializer, topSerializer, 
-        indexedSlicesInternal(predicate, slicePredicate), mapper);
-  }
+	protected <R, V> MappedColumnFamilyResult<K, N, R> doExecuteIndexedSlices(
+			IndexedSlicesPredicate<K, N, V> predicate, ColumnFamilyRowMapper<K, N, R> mapper)
+	{
+		return new MappedColumnFamilyResultWrapper<K, N, R>(keySerializer, topSerializer,
+				indexedSlicesInternal(predicate, activeSlicePredicate), mapper);
+	}
 
-  private ExecutionResult<Map<ByteBuffer, List<ColumnOrSuperColumn>>> sliceInternal(final K key,
-      final HSlicePredicate<N> workingSlicePredicate) {
-    return ((ExecutingKeyspace)keyspace).doExecuteOperation(new Operation<Map<ByteBuffer,List<ColumnOrSuperColumn>>>(OperationType.READ) {
-      @Override
-      public Map<ByteBuffer,List<ColumnOrSuperColumn>> execute(Cassandra.Client cassandra) throws HectorException {
-        Map<ByteBuffer,List<ColumnOrSuperColumn>> cosc = new LinkedHashMap<ByteBuffer, List<ColumnOrSuperColumn>>();
-        try {          
+	protected <R, V> MappedColumnFamilyResult<K, N, R> doExecuteIndexedSlices(
+			IndexedSlicesPredicate<K, N, V> predicate, HSlicePredicate<N> slicePredicate,
+			ColumnFamilyRowMapper<K, N, R> mapper)
+	{
+		return new MappedColumnFamilyResultWrapper<K, N, R>(keySerializer, topSerializer,
+				indexedSlicesInternal(predicate, slicePredicate), mapper);
+	}
 
-          ByteBuffer sKey = keySerializer.toByteBuffer(key);
-          cosc.put(sKey, cassandra.get_slice(sKey, columnParent,
-              workingSlicePredicate.toThrift(), 
-              ThriftConverter.consistencyLevel(consistencyLevelPolicy.get(operationType, columnFamily))));
+	private ExecutionResult<Map<ByteBuffer, List<ColumnOrSuperColumn>>> sliceInternal(final K key,
+			final HSlicePredicate<N> workingSlicePredicate)
+	{
+		final HConsistencyLevel consistencyLevel = consistencyLevelPolicy.get(OperationType.READ,
+				columnFamily);
 
-        } catch (Exception e) {
-          throw exceptionsTranslator.translate(e);
-        }        
+		return ((ExecutingKeyspace) keyspace)
+				.doExecuteOperation(new Operation<Map<ByteBuffer, List<ColumnOrSuperColumn>>>(
+						OperationType.READ)
+				{
+					@Override
+					public Map<ByteBuffer, List<ColumnOrSuperColumn>> execute(
+							Cassandra.Client cassandra) throws HectorException
+					{
+						Map<ByteBuffer, List<ColumnOrSuperColumn>> cosc = new LinkedHashMap<ByteBuffer, List<ColumnOrSuperColumn>>();
+						try
+						{
 
-        return cosc;
-      }
-    });
-  }
+							ByteBuffer sKey = keySerializer.toByteBuffer(key);
+							cosc.put(
+									sKey,
+									cassandra.get_slice(sKey, columnParent,
+											workingSlicePredicate.toThrift(),
+											ThriftConverter.consistencyLevel(consistencyLevel)));
 
-  private ExecutionResult<Map<ByteBuffer, List<ColumnOrSuperColumn>>> multigetSliceInternal(final Iterable<K> keys,
-      final HSlicePredicate<N> workingSlicePredicate) {
-    return ((ExecutingKeyspace)keyspace).doExecuteOperation(new Operation<Map<ByteBuffer,List<ColumnOrSuperColumn>>>(OperationType.READ) {
-      @Override
-      public Map<ByteBuffer,List<ColumnOrSuperColumn>> execute(Cassandra.Client cassandra) throws HectorException {
-        try {          
-          List<K> keyList = new ArrayList<K>();
-          Iterators.addAll(keyList, keys.iterator());
-          return cassandra.multiget_slice(keySerializer.toBytesList(keyList), columnParent,
-              (workingSlicePredicate == null ? activeSlicePredicate.setColumnNames(columnValueSerializers.keySet()).toThrift() : workingSlicePredicate.toThrift()),              
-            ThriftConverter.consistencyLevel(consistencyLevelPolicy.get(operationType, columnFamily)));
-        } catch (Exception e) {
-          throw exceptionsTranslator.translate(e);
-        }
-      }
-    });
-  }
+						}
+						catch (Exception e)
+						{
+							throw exceptionsTranslator.translate(e);
+						}
 
-  private <V> ExecutionResult<Map<ByteBuffer, List<ColumnOrSuperColumn>>> indexedSlicesInternal(
-      final IndexedSlicesPredicate<K, N, V> predicate, 
-      final HSlicePredicate<N> workingSlicePredicate) {
-    return ((ExecutingKeyspace)keyspace).doExecuteOperation(new Operation<Map<ByteBuffer,List<ColumnOrSuperColumn>>>(OperationType.READ) {
-      @Override
-      public Map<ByteBuffer, List<ColumnOrSuperColumn>> execute(Client cassandra) throws HectorException {
-        try {
-          List<KeySlice> keySlices = cassandra.get_indexed_slices(
-              columnParent,
-              predicate.toThrift(), 
-              workingSlicePredicate.toThrift(),
-              ThriftConverter.consistencyLevel(consistencyLevelPolicy.get(operationType, columnFamily)));
-          if (keySlices == null || keySlices.isEmpty()) {
-            return new LinkedHashMap<ByteBuffer, List<ColumnOrSuperColumn>>(0);
-          }
-          LinkedHashMap<ByteBuffer, List<ColumnOrSuperColumn>> ret = 
-              new LinkedHashMap<ByteBuffer, List<ColumnOrSuperColumn>>(keySlices.size());
-          for (KeySlice keySlice : keySlices) {
-            ret.put(ByteBuffer.wrap(keySlice.getKey()), keySlice.getColumns());
-          }
-          return ret;
-        } catch (Exception e) {
-          throw exceptionsTranslator.translate(e);
-        }
-      }
-    });
-  }
+						return cosc;
+					}
+				});
+	}
+
+	private ExecutionResult<Map<ByteBuffer, List<ColumnOrSuperColumn>>> multigetSliceInternal(
+			final Iterable<K> keys, final HSlicePredicate<N> workingSlicePredicate)
+	{
+		final HConsistencyLevel consistencyLevel = consistencyLevelPolicy.get(OperationType.READ,
+				columnFamily);
+		return ((ExecutingKeyspace) keyspace)
+				.doExecuteOperation(new Operation<Map<ByteBuffer, List<ColumnOrSuperColumn>>>(
+						OperationType.READ)
+				{
+					@Override
+					public Map<ByteBuffer, List<ColumnOrSuperColumn>> execute(
+							Cassandra.Client cassandra) throws HectorException
+					{
+						try
+						{
+							List<K> keyList = new ArrayList<K>();
+							Iterators.addAll(keyList, keys.iterator());
+							return cassandra.multiget_slice(keySerializer.toBytesList(keyList),
+									columnParent,
+									(workingSlicePredicate == null ? activeSlicePredicate
+											.setColumnNames(columnValueSerializers.keySet())
+											.toThrift() : workingSlicePredicate.toThrift()),
+									ThriftConverter.consistencyLevel(consistencyLevel));
+						}
+						catch (Exception e)
+						{
+							throw exceptionsTranslator.translate(e);
+						}
+					}
+				});
+	}
+
+	private <V> ExecutionResult<Map<ByteBuffer, List<ColumnOrSuperColumn>>> indexedSlicesInternal(
+			final IndexedSlicesPredicate<K, N, V> predicate,
+			final HSlicePredicate<N> workingSlicePredicate)
+	{
+		final HConsistencyLevel consistencyLevel = consistencyLevelPolicy.get(OperationType.READ,
+				columnFamily);
+		return ((ExecutingKeyspace) keyspace)
+				.doExecuteOperation(new Operation<Map<ByteBuffer, List<ColumnOrSuperColumn>>>(
+						OperationType.READ)
+				{
+					@Override
+					public Map<ByteBuffer, List<ColumnOrSuperColumn>> execute(Client cassandra)
+							throws HectorException
+					{
+						try
+						{
+							List<KeySlice> keySlices = cassandra.get_indexed_slices(columnParent,
+									predicate.toThrift(), workingSlicePredicate.toThrift(),
+									ThriftConverter.consistencyLevel(consistencyLevel));
+							if (keySlices == null || keySlices.isEmpty())
+							{
+								return new LinkedHashMap<ByteBuffer, List<ColumnOrSuperColumn>>(0);
+							}
+							LinkedHashMap<ByteBuffer, List<ColumnOrSuperColumn>> ret = new LinkedHashMap<ByteBuffer, List<ColumnOrSuperColumn>>(
+									keySlices.size());
+							for (KeySlice keySlice : keySlices)
+							{
+								ret.put(ByteBuffer.wrap(keySlice.getKey()), keySlice.getColumns());
+							}
+							return ret;
+						}
+						catch (Exception e)
+						{
+							throw exceptionsTranslator.translate(e);
+						}
+					}
+				});
+	}
 }

--- a/core/src/main/java/me/prettyprint/cassandra/service/template/ThriftSuperCfTemplate.java
+++ b/core/src/main/java/me/prettyprint/cassandra/service/template/ThriftSuperCfTemplate.java
@@ -5,88 +5,115 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.cassandra.thrift.Cassandra;
-import org.apache.cassandra.thrift.ColumnOrSuperColumn;
-import org.apache.cassandra.thrift.ColumnParent;
-
 import me.prettyprint.cassandra.model.ExecutingKeyspace;
 import me.prettyprint.cassandra.model.ExecutionResult;
 import me.prettyprint.cassandra.model.HSlicePredicate;
 import me.prettyprint.cassandra.model.thrift.ThriftConverter;
 import me.prettyprint.cassandra.service.Operation;
 import me.prettyprint.cassandra.service.OperationType;
+import me.prettyprint.hector.api.HConsistencyLevel;
 import me.prettyprint.hector.api.Keyspace;
 import me.prettyprint.hector.api.Serializer;
 import me.prettyprint.hector.api.exceptions.HectorException;
 
-public class ThriftSuperCfTemplate<K, SN, N> extends SuperCfTemplate<K, SN, N> {
+import org.apache.cassandra.thrift.Cassandra;
+import org.apache.cassandra.thrift.ColumnOrSuperColumn;
+import org.apache.cassandra.thrift.ColumnParent;
 
-  public ThriftSuperCfTemplate(Keyspace keyspace, String columnFamily,
-      Serializer<K> keySerializer, Serializer<SN> topSerializer,
-      Serializer<N> subSerializer) {
-    super(keyspace, columnFamily, keySerializer, topSerializer, subSerializer);
-  }
-  
-  protected SuperCfResult<K,SN,N> doExecuteSlice(K key, SN sColumnName, HSlicePredicate<SN> predicate) {    
-    SuperCfResultWrapper<K, SN, N> wrapper = 
-      new SuperCfResultWrapper<K, SN, N>(keySerializer, topSerializer, subSerializer, 
-          sliceInternal(key, predicate));
-    if ( sColumnName != null ) {
-      wrapper.applySuperColumn(sColumnName);
-    }
-    return wrapper;
-  } 
-  
-  protected SuperCfResult<K,SN,N> doExecuteMultigetSlice(List<K> keys, HSlicePredicate<SN> predicate) {    
-    SuperCfResultWrapper<K, SN, N> wrapper = 
-      new SuperCfResultWrapper<K, SN, N>(keySerializer, topSerializer, subSerializer, 
-          multigetSliceInternal(keys, columnParent, predicate));    
-    return wrapper;
-  } 
-  
-  private ExecutionResult<Map<ByteBuffer, List<ColumnOrSuperColumn>>> sliceInternal(final K key,
-      final HSlicePredicate<SN> workingSlicePredicate) {
-    return ((ExecutingKeyspace)keyspace).doExecuteOperation(new Operation<Map<ByteBuffer,List<ColumnOrSuperColumn>>>(OperationType.READ) {
-      @Override
-      public Map<ByteBuffer,List<ColumnOrSuperColumn>> execute(Cassandra.Client cassandra) throws HectorException {
-        Map<ByteBuffer,List<ColumnOrSuperColumn>> cosc = new LinkedHashMap<ByteBuffer, List<ColumnOrSuperColumn>>();
-        try {          
+public class ThriftSuperCfTemplate<K, SN, N> extends SuperCfTemplate<K, SN, N>
+{
 
-          ByteBuffer sKey = keySerializer.toByteBuffer(key);
-          cosc.put(sKey, cassandra.get_slice(sKey, columnParent,
-              workingSlicePredicate.toThrift(), 
-              ThriftConverter.consistencyLevel(consistencyLevelPolicy.get(operationType))));
+	public ThriftSuperCfTemplate(Keyspace keyspace, String columnFamily,
+			Serializer<K> keySerializer, Serializer<SN> topSerializer, Serializer<N> subSerializer)
+	{
+		super(keyspace, columnFamily, keySerializer, topSerializer, subSerializer);
+	}
 
-        } catch (Exception e) {
-          throw exceptionsTranslator.translate(e);
-        }        
+	protected SuperCfResult<K, SN, N> doExecuteSlice(K key, SN sColumnName,
+			HSlicePredicate<SN> predicate)
+	{
+		SuperCfResultWrapper<K, SN, N> wrapper = new SuperCfResultWrapper<K, SN, N>(keySerializer,
+				topSerializer, subSerializer, sliceInternal(key, predicate));
+		if (sColumnName != null)
+		{
+			wrapper.applySuperColumn(sColumnName);
+		}
+		return wrapper;
+	}
 
-        return cosc;
-      }
-    });
-  }
-  
-  private ExecutionResult<Map<ByteBuffer, List<ColumnOrSuperColumn>>> multigetSliceInternal(final List<K> keys,
-      final ColumnParent workingColumnParent,
-      final HSlicePredicate<SN> workingSlicePredicate) {
-    return ((ExecutingKeyspace)keyspace).doExecuteOperation(new Operation<Map<ByteBuffer,List<ColumnOrSuperColumn>>>(OperationType.READ) {
-      @Override
-      public Map<ByteBuffer,List<ColumnOrSuperColumn>> execute(Cassandra.Client cassandra) throws HectorException {
-        Map<ByteBuffer,List<ColumnOrSuperColumn>> cosc;
-        try {          
+	protected SuperCfResult<K, SN, N> doExecuteMultigetSlice(List<K> keys,
+			HSlicePredicate<SN> predicate)
+	{
+		SuperCfResultWrapper<K, SN, N> wrapper = new SuperCfResultWrapper<K, SN, N>(keySerializer,
+				topSerializer, subSerializer, multigetSliceInternal(keys, columnParent, predicate));
+		return wrapper;
+	}
 
-          List<ByteBuffer> sKeys = keySerializer.toBytesList(keys);
-          cosc = cassandra.multiget_slice(sKeys, workingColumnParent,
-              workingSlicePredicate.toThrift(), 
-              ThriftConverter.consistencyLevel(consistencyLevelPolicy.get(operationType)));
+	private ExecutionResult<Map<ByteBuffer, List<ColumnOrSuperColumn>>> sliceInternal(final K key,
+			final HSlicePredicate<SN> workingSlicePredicate)
+	{
+		final HConsistencyLevel consistencyLevel = consistencyLevelPolicy.get(OperationType.READ);
+		return ((ExecutingKeyspace) keyspace)
+				.doExecuteOperation(new Operation<Map<ByteBuffer, List<ColumnOrSuperColumn>>>(
+						OperationType.READ)
+				{
+					@Override
+					public Map<ByteBuffer, List<ColumnOrSuperColumn>> execute(
+							Cassandra.Client cassandra) throws HectorException
+					{
+						Map<ByteBuffer, List<ColumnOrSuperColumn>> cosc = new LinkedHashMap<ByteBuffer, List<ColumnOrSuperColumn>>();
+						try
+						{
 
-        } catch (Exception e) {
-          throw exceptionsTranslator.translate(e);
-        }        
+							ByteBuffer sKey = keySerializer.toByteBuffer(key);
+							cosc.put(
+									sKey,
+									cassandra.get_slice(sKey, columnParent,
+											workingSlicePredicate.toThrift(),
+											ThriftConverter.consistencyLevel(consistencyLevel)));
 
-        return cosc;
-      }
-    });
-  }
+						}
+						catch (Exception e)
+						{
+							throw exceptionsTranslator.translate(e);
+						}
+
+						return cosc;
+					}
+				});
+	}
+
+	private ExecutionResult<Map<ByteBuffer, List<ColumnOrSuperColumn>>> multigetSliceInternal(
+			final List<K> keys, final ColumnParent workingColumnParent,
+			final HSlicePredicate<SN> workingSlicePredicate)
+	{
+		final HConsistencyLevel consistencyLevel = consistencyLevelPolicy.get(OperationType.READ);
+		return ((ExecutingKeyspace) keyspace)
+				.doExecuteOperation(new Operation<Map<ByteBuffer, List<ColumnOrSuperColumn>>>(
+						OperationType.READ)
+				{
+					@Override
+					public Map<ByteBuffer, List<ColumnOrSuperColumn>> execute(
+							Cassandra.Client cassandra) throws HectorException
+					{
+						Map<ByteBuffer, List<ColumnOrSuperColumn>> cosc;
+						try
+						{
+
+							List<ByteBuffer> sKeys = keySerializer.toBytesList(keys);
+							cosc = cassandra.multiget_slice(sKeys, workingColumnParent,
+									workingSlicePredicate.toThrift(),
+									ThriftConverter.consistencyLevel(consistencyLevel));
+
+						}
+						catch (Exception e)
+						{
+							throw exceptionsTranslator.translate(e);
+						}
+
+						return cosc;
+					}
+				});
+	}
 
 }


### PR DESCRIPTION
Right now the call to consistencyLevel.get() is always done inside the anonymous Operation<T> class at runtime, when the operation is EXECUTED, and possibly in a thread different from the calling thread.

This design prevents the ConfigurableConsistencyLevel to set dynamic level at runtime because at the time the operation is executed, consistencyLevel.get()  may return a different value.

Ideally the level should be determined and set before creating the anonymous Operation<T> .

 This pull request introduces a slight modification to solve this issue
