### PR TITLE
Patch for issue #584: operateWithFailover fails against c* 1.2.1 when authentication is enabled

### DIFF
--- a/core/src/main/java/me/prettyprint/cassandra/connection/HConnectionManager.java
+++ b/core/src/main/java/me/prettyprint/cassandra/connection/HConnectionManager.java
@@ -248,12 +248,12 @@ public class HConnectionManager {
         // TODO how to 'timeout' on this op when underlying pool is exhausted
         pool = getClientFromLBPolicy(excludeHosts);
         client = pool.borrowClient();
-        Cassandra.Client c = client.getCassandra(op.keyspaceName);
         // Keyspace can be null for some system_* api calls
         if ( op.credentials != null && !op.credentials.isEmpty() && !client.isAlreadyAuthenticated(op.credentials)) {
-          c.login(new AuthenticationRequest(op.credentials));
+          client.getCassandra().login(new AuthenticationRequest(op.credentials));
           client.setAuthenticated(op.credentials);
         }
+        Cassandra.Client c = client.getCassandra(op.keyspaceName);
 
         op.executeAndSetResult(c, pool.getCassandraHost());
         success = true;


### PR DESCRIPTION
Almost the same code amendment as in biddster's comment on issue #584.
