### PR TITLE
set RangeSlicesIterator.endKey field

### DIFF
--- a/core/src/main/java/me/prettyprint/cassandra/service/RangeSlicesIterator.java
+++ b/core/src/main/java/me/prettyprint/cassandra/service/RangeSlicesIterator.java
@@ -24,6 +24,7 @@ public class RangeSlicesIterator<K, N, V> implements Iterator<Row<K, N, V>> {
 	public RangeSlicesIterator(RangeSlicesQuery<K, N, V> query, K startKey, K endKey) {
 		this.query = query;
 		this.startKey = startKey;
+		this.endKey = endKey;
 
 		this.query.setKeys(startKey, endKey);
 	}


### PR DESCRIPTION
code accesses endKey field throughout the class, but it never sets it in the constructor... added.
