### PR TITLE
Fixed issue where all locks are release, but the wait run loop is still

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -206,6 +206,14 @@
       <version>${org.springframework.version}</version>
       <scope>test</scope>
     </dependency>
+    
+    <!--  override borked snappy version if you're running os x -->
+    <dependency>
+      <groupId>org.xerial.snappy</groupId>
+      <artifactId>snappy-java</artifactId>
+      <version>1.0.5-M4</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>


### PR DESCRIPTION
executing.  In this case, no matches will be returned.  As a result, the
check for no other lock contention needs to be first in the list.  Otherwise the list ordering operations will fail.
