### PR TITLE
Add ability to specify columns for multiget queryColumns

### DIFF
--- a/core/src/main/java/me/prettyprint/cassandra/service/template/ColumnFamilyTemplate.java
+++ b/core/src/main/java/me/prettyprint/cassandra/service/template/ColumnFamilyTemplate.java
@@ -160,6 +160,12 @@ public abstract class ColumnFamilyTemplate<K, N> extends AbstractColumnFamilyTem
     return doExecuteSlice(key, predicate);
   }
 
+  public ColumnFamilyResult<K, N> queryColumns(Iterable<K> keys, List<N> columns) {
+    HSlicePredicate<N> predicate = new HSlicePredicate<N>(topSerializer);
+    predicate.setColumnNames(columns);        
+    return doExecuteMultigetSlice(keys, predicate);
+  }
+
   public ColumnFamilyResult<K, N> queryColumns(K key, HSlicePredicate<N> predicate) {
     return doExecuteSlice(key, predicate);
   }

--- a/core/src/test/java/me/prettyprint/cassandra/service/template/ColumnFamilyTemplateTest.java
+++ b/core/src/test/java/me/prettyprint/cassandra/service/template/ColumnFamilyTemplateTest.java
@@ -54,6 +54,30 @@ public class ColumnFamilyTemplateTest extends BaseColumnFamilyTemplateTest {
     assertEquals(3,wrapper.getColumnNames().size());
   }
 
+  @Test
+  public void testCreateSelectSpecifiedColumn() {
+    ColumnFamilyTemplate<String, String> template = new ThriftColumnFamilyTemplate<String, String>(keyspace, "Standard1", se, se);
+    
+    ColumnFamilyUpdater<String,String> updater = template.createUpdater("csskey1"); 
+    updater.setString("col1","value1");
+    updater.setString("col2","value2");
+    updater.setString("col3","value3");
+    updater.setString("col4","value4");
+    updater.setString("col5","value5");
+    template.update(updater);
+    
+    template.addColumn("stringval", se);
+    template.addColumn("curdate", DateSerializer.get());
+    template.addColumn("longval", LongSerializer.get());
+    ColumnFamilyResult<String,String> wrapper = template.queryColumns("csskey1", Arrays.asList("col1", "col3", "col5"));    
+    assertEquals("value1",wrapper.getString("col1"));
+    assertNull(wrapper.getString("col2"));
+    assertEquals("value3",wrapper.getString("col3"));
+    assertNull(wrapper.getString("col4"));
+    assertEquals("value5",wrapper.getString("col5"));
+    assertEquals(3,wrapper.getColumnNames().size());
+  }
+
     @Test
   public void testCompareClocks() {
     ColumnFamilyTemplate<String, String> template = new ThriftColumnFamilyTemplate<String, String>(keyspace, "Standard1", se, se);
@@ -171,6 +195,42 @@ public class ColumnFamilyTemplateTest extends BaseColumnFamilyTemplateTest {
     assertEquals("value2",wrapper.getString("column1"));
     wrapper.next();
     assertEquals("value3",wrapper.getString("column1"));
+  }
+  
+  @Test
+  public void testQueryMultigetSpecificColumns() {
+    ColumnFamilyTemplate<String, String> template = new ThriftColumnFamilyTemplate<String, String>(keyspace, "Standard1", se, se);    
+    ColumnFamilyUpdater<String,String> updater = template.createUpdater("mgs_key1"); 
+    updater.setString("column1","value1-1");
+    updater.setString("column2","value2-1");
+    updater.setString("column3","value3-1");
+    updater.addKey("mgs_key2");
+    updater.setString("column1","value1-2");
+    updater.setString("column2","value2-2");
+    updater.setString("column3","value3-2");
+    updater.addKey("mgs_key3");
+    updater.setString("column1","value1-3");
+    updater.setString("column2","value2-3");
+    updater.setString("column3","value3-3");
+    template.update(updater);
+    
+    template.addColumn("column1", se);
+    template.addColumn("column2", se);
+    template.addColumn("column3", se);
+    ColumnFamilyResult<String,String> wrapper = template.queryColumns(Arrays.asList("mgs_key1", "mgs_key2", "mgs_key3"), Arrays.asList("column1", "column3"));
+    assertEquals("value1-1",wrapper.getString("column1")); 
+    assertNull(wrapper.getString("column2")); 
+    assertEquals("value3-1",wrapper.getString("column3")); 
+    wrapper.next();
+
+    assertEquals("value1-2",wrapper.getString("column1"));
+    assertNull(wrapper.getString("column2")); 
+    assertEquals("value3-2",wrapper.getString("column3")); 
+    wrapper.next();
+
+    assertEquals("value1-3",wrapper.getString("column1"));
+    assertNull(wrapper.getString("column2")); 
+    assertEquals("value3-3",wrapper.getString("column3")); 
   }
   
   @Test


### PR DESCRIPTION
ColumnFamilyTemplate has a queryColumns method for a single key where you can specify which columns to return.

public ColumnFamilyResult<K, N> queryColumns(K key, List<N> columns)

There was no multiget equivalent though i.e:

public ColumnFamilyResult<K, N> queryColumns(Iterable<K> keys, List<N> columns)

Only a method that requires you use a ColumnFamilyRowMapper:

public <V> MappedColumnFamilyResult<K,N,V> queryColumns(Iterable<K> keys, List<N> columns, ColumnFamilyRowMapper<K, N, V> mapper)

https://groups.google.com/forum/?fromgroups#!topic/hector-users/xsS9N8ld6L4
