### PR TITLE
ref hector-client/hector#600

### DIFF
--- a/core/src/main/java/me/prettyprint/cassandra/model/CqlQuery.java
+++ b/core/src/main/java/me/prettyprint/cassandra/model/CqlQuery.java
@@ -109,11 +109,8 @@ public class CqlQuery<K, N, V> extends AbstractBasicQuery<K, N, CqlRows<K,N,V>> 
           public CqlRows<K, N, V> execute(Client cassandra) throws HectorException {
             CqlRows<K, N, V> rows = null;
             try {
-              if (cqlVersion != null){
-                if (! cqlVersion.equals(keyspace.cqlVersion)){
+              if (cqlVersion != null) {
                   cassandra.set_cql_version(cqlVersion);
-                  keyspace.setCqlVersion(cqlVersion);
-                }
               }
               CqlResult result = cassandra.execute_cql_query(query, 
                   useCompression ? Compression.GZIP : Compression.NONE);

--- a/core/src/main/java/me/prettyprint/cassandra/model/ExecutingKeyspace.java
+++ b/core/src/main/java/me/prettyprint/cassandra/model/ExecutingKeyspace.java
@@ -81,17 +81,6 @@ public class ExecutingKeyspace implements Keyspace {
     return connectionManager.createClock();
   }
 
-  public String getCqlVersion() {
-    return cqlVersion;
-  }
-
-  @Override
-  public void setCqlVersion(String cqlVersion) {
-    this.cqlVersion = cqlVersion;
-  }
-
-
-
   public <T> ExecutionResult<T> doExecute(KeyspaceOperationCallback<T> koc)
       throws HectorException {
     KeyspaceService ks = null;

--- a/core/src/main/java/me/prettyprint/hector/api/Keyspace.java
+++ b/core/src/main/java/me/prettyprint/hector/api/Keyspace.java
@@ -15,7 +15,4 @@ public interface Keyspace {
   String getKeyspaceName();
   
   long createClock();
-
-  void setCqlVersion(String version);
-
 }


### PR DESCRIPTION
If CQL version is set for a query, then enforce that for each execution.
That will cost 1 additional call to Cassandra only if the version is set for a query. 
