### PR TITLE
Slightly relaxed synchronization

### DIFF
--- a/core/src/main/java/me/prettyprint/hector/api/factory/HFactory.java
+++ b/core/src/main/java/me/prettyprint/hector/api/factory/HFactory.java
@@ -213,8 +213,8 @@ public final class HFactory {
    * @param cluster
    */
   public static void shutdownCluster(Cluster cluster) {
-    synchronized (clusters) {
       String clusterName = cluster.getName();
+      synchronized (clusters) {
       if (clusters.get(clusterName) != null ) {
         cluster.getConnectionManager().shutdown();
         clusters.remove(clusterName);


### PR DESCRIPTION
there is no need to hold the lock while querying for the cluster name
