### PR TITLE
added support to hector exceptions to display the host

### DIFF
--- a/core/src/main/java/me/prettyprint/cassandra/service/ExceptionsTranslatorImpl.java
+++ b/core/src/main/java/me/prettyprint/cassandra/service/ExceptionsTranslatorImpl.java
@@ -4,11 +4,9 @@ import java.net.SocketTimeoutException;
 import java.util.NoSuchElementException;
 
 import me.prettyprint.hector.api.exceptions.HCassandraInternalException;
-import me.prettyprint.hector.api.exceptions.HInactivePoolException;
 import me.prettyprint.hector.api.exceptions.HInvalidRequestException;
 import me.prettyprint.hector.api.exceptions.HNotFoundException;
 import me.prettyprint.hector.api.exceptions.HPoolExhaustedException;
-import me.prettyprint.hector.api.exceptions.HPoolRecoverableException;
 import me.prettyprint.hector.api.exceptions.HTimedOutException;
 import me.prettyprint.hector.api.exceptions.HUnavailableException;
 import me.prettyprint.hector.api.exceptions.HectorException;


### PR DESCRIPTION
Sorry about the second go at this, Nate.  I reviewed my changes and saw that I missed a case (translating TApplicationException to HCassandraInternalException), and also that is could be cleaner to only call setHost() once instead of over a dozen times.
