### PR TITLE
Make links go to hector.github.io

### DIFF
--- a/source/content/api.rst
+++ b/source/content/api.rst
@@ -8,22 +8,22 @@ API
 Core
 ====
 
-`0.8.0-2 <http://hector-client.org/source/content/API/core/0.8.0-2/index.html>`_
+`0.8.0-2 <http://hector-client.github.io/hector/source/content/API/core/0.8.0-2/index.html>`_
 
-`1.0-1 <http://hector-client.org/source/content/API/core/1.0-1/index.html>`_
+`1.0-1 <http://hector-client.github.io/hector/source/content/API/core/1.0-1/index.html>`_
 
 ====
 Test
 ====
 
-`1.0-1 <http://hector-client.org/source/content/API/test/1.0-1/index.html>`_
+`1.0-1 <http://hector-client.github.io/hector/source/content/API/test/1.0-1/index.html>`_
 
 ===
 HOM
 ===
 
-`1.1-02 <http://hector-client.org/source/content/API/HOM/1.1-02/index.html>`_
+`1.1-02 <http://hector-client.github.io/hector/source/content/API/HOM/1.1-02/index.html>`_
 
-`2.0-01 <http://hector-client.org/source/content/API/HOM/2.0-01/index.html>`_
+`2.0-01 <http://hector-client.github.io/hector/source/content/API/HOM/2.0-01/index.html>`_
 
-`3.0-01 <http://hector-client.org/source/content/API/HOM/3.0-01/index.html>`_
+`3.0-01 <http://hector-client.github.io/hector/source/content/API/HOM/3.0-01/index.html>`_


### PR DESCRIPTION
hector-client.org doesn't appear to host these docs.
