### PR TITLE
issue-650 DynamicLoadBalancingPolicy: LatencyAwareHClientPool may throw ...

### DIFF
--- a/core/src/main/java/me/prettyprint/cassandra/connection/LatencyAwareHClientPool.java
+++ b/core/src/main/java/me/prettyprint/cassandra/connection/LatencyAwareHClientPool.java
@@ -45,7 +45,7 @@ public class LatencyAwareHClientPool extends ConcurrentHClientPool {
     if (intervalupdates.intValue() >= UPDATES_PER_INTERVAL)
       return;
     if (!latencies.offer(i)) {
-      latencies.remove();
+      latencies.poll();
       latencies.offer(i);
     }
     intervalupdates.getAndIncrement();


### PR DESCRIPTION
...NoSuchElementException under certain circumstances

Using the poll() method of the LinkedBlockingDeque prevent
NoSuchElementException to be thrown in case the deque is cleared by the
DynamicLoadBalancingPolicy resetThread.
