### PR TITLE
Make setConsistencyLevel method available for all queries/mutator and not just for CQL queries

### DIFF
--- a/core/src/main/java/me/prettyprint/cassandra/model/AbstractBasicQuery.java
+++ b/core/src/main/java/me/prettyprint/cassandra/model/AbstractBasicQuery.java
@@ -69,10 +69,12 @@ public abstract class AbstractBasicQuery<K, N, T> implements Query<T> {
     return this;
   }
   
+  @Override
   public HConsistencyLevel getConsistencyLevel() {
 	  return this.consistency;
   }
 
+  @Override
   public void setConsistencyLevel(HConsistencyLevel level) {
 	  this.consistency = level;
   }

--- a/core/src/main/java/me/prettyprint/cassandra/model/AbstractSubColumnQuery.java
+++ b/core/src/main/java/me/prettyprint/cassandra/model/AbstractSubColumnQuery.java
@@ -3,6 +3,7 @@ package me.prettyprint.cassandra.model;
 import java.util.List;
 
 import me.prettyprint.cassandra.utils.Assert;
+import me.prettyprint.hector.api.HConsistencyLevel;
 import me.prettyprint.hector.api.Keyspace;
 import me.prettyprint.hector.api.Serializer;
 import me.prettyprint.hector.api.beans.ColumnSlice;
@@ -53,6 +54,16 @@ public class AbstractSubColumnQuery<K, SN, N, V> implements SubColumnQuery<K, SN
   public SubColumnQuery<K, SN, N, V> setColumnFamily(String cf) {
     subSliceQuery.setColumnFamily(cf);
     return this;
+  }
+
+  @Override
+  public HConsistencyLevel getConsistencyLevel() {
+	  return this.subSliceQuery.getConsistencyLevel();
+  }
+
+  @Override
+  public void setConsistencyLevel(HConsistencyLevel level) {
+	  this.subSliceQuery.setConsistencyLevel(level);
   }
 
   @Override

--- a/core/src/main/java/me/prettyprint/cassandra/model/IndexedSlicesQuery.java
+++ b/core/src/main/java/me/prettyprint/cassandra/model/IndexedSlicesQuery.java
@@ -152,7 +152,7 @@ public class IndexedSlicesQuery<K, N, V> extends
                 (LinkedHashMap<K, List<Column>>) thriftRet,
                 columnNameSerializer, valueSerializer);
           }
-        }), this);
+        }, consistency), this);
   }
 
 }

--- a/core/src/main/java/me/prettyprint/cassandra/model/MultigetCountQuery.java
+++ b/core/src/main/java/me/prettyprint/cassandra/model/MultigetCountQuery.java
@@ -6,6 +6,7 @@ import java.util.Map;
 
 import me.prettyprint.cassandra.service.KeyspaceService;
 import me.prettyprint.cassandra.utils.Assert;
+import me.prettyprint.hector.api.HConsistencyLevel;
 import me.prettyprint.hector.api.Keyspace;
 import me.prettyprint.hector.api.Serializer;
 import me.prettyprint.hector.api.exceptions.HectorException;
@@ -20,7 +21,8 @@ public class MultigetCountQuery<K,N> implements Query<Map<K, Integer>> {
   protected final Serializer<K> keySerializer;
   protected String columnFamily;
   protected List<K> keys;
-
+  protected HConsistencyLevel consistency;
+  
   /** The slice predicate for which the count it performed*/
   protected final HSlicePredicate<N> slicePredicate;
 
@@ -55,6 +57,16 @@ public class MultigetCountQuery<K,N> implements Query<Map<K, Integer>> {
   }
 
   @Override
+  public HConsistencyLevel getConsistencyLevel() {
+	  return this.consistency;
+  }
+
+  @Override
+  public void setConsistencyLevel(HConsistencyLevel level) {
+	  this.consistency = level;
+  }
+
+  @Override
   public QueryResult<Map<K, Integer>> execute() {
     Assert.notNull(keys, "keys list is null");
     Assert.notNull(columnFamily, "columnFamily is null");
@@ -67,7 +79,7 @@ public class MultigetCountQuery<K,N> implements Query<Map<K, Integer>> {
                 ks.multigetCount(keySerializer.toBytesList(keys), columnParent, slicePredicate.toThrift()));
             return counts;
           }
-        }), this);
+        }, consistency), this);
   }
 
   @Override

--- a/core/src/main/java/me/prettyprint/cassandra/model/MultigetSubCountQuery.java
+++ b/core/src/main/java/me/prettyprint/cassandra/model/MultigetSubCountQuery.java
@@ -50,6 +50,6 @@ public class MultigetSubCountQuery<K,SN,N> extends MultigetCountQuery<K, N> {
                 ks.multigetCount(keySerializer.toBytesList(keys), columnParent, slicePredicate.toThrift()));
             return counts;
           }
-        }), this);
+        }, consistency), this);
   }
 }

--- a/core/src/main/java/me/prettyprint/cassandra/model/MutatorImpl.java
+++ b/core/src/main/java/me/prettyprint/cassandra/model/MutatorImpl.java
@@ -7,6 +7,7 @@ import me.prettyprint.cassandra.model.thrift.ThriftConverter;
 import me.prettyprint.cassandra.model.thrift.ThriftFactory;
 import me.prettyprint.cassandra.serializers.TypeInferringSerializer;
 import me.prettyprint.cassandra.service.*;
+import me.prettyprint.hector.api.HConsistencyLevel;
 import me.prettyprint.hector.api.Keyspace;
 import me.prettyprint.hector.api.Serializer;
 import me.prettyprint.hector.api.beans.HColumn;
@@ -45,6 +46,8 @@ public final class MutatorImpl<K> implements Mutator<K> {
   private BatchMutation<K> pendingMutations;
   
   private BatchSizeHint sizeHint;
+  
+  private HConsistencyLevel consistency;
 
   public MutatorImpl(Keyspace keyspace, Serializer<K> keySerializer, BatchSizeHint sizeHint) {
     this.keyspace = (ExecutingKeyspace) keyspace;
@@ -62,6 +65,16 @@ public final class MutatorImpl<K> implements Mutator<K> {
 
   public MutatorImpl(Keyspace keyspace, BatchSizeHint sizeHint) {
     this(keyspace, TypeInferringSerializer.<K> get(), sizeHint);
+  }
+  
+  @Override
+  public HConsistencyLevel getConsistencyLevel() {
+	  return this.consistency;
+  }
+
+  @Override
+  public void setConsistencyLevel(HConsistencyLevel level) {
+	  this.consistency = level;
   }
   
   // Simple and immediate insertion of a column
@@ -110,7 +123,7 @@ public final class MutatorImpl<K> implements Mutator<K> {
             supercolumnName, columnName, sNameSerializer, nameSerializer));
         return null;
       }
-    }));
+    }, consistency));
   }  
   
   @Override
@@ -125,7 +138,7 @@ public final class MutatorImpl<K> implements Mutator<K> {
               ThriftFactory.createSuperColumnPath(cf, supercolumnName, sNameSerializer));
           return null;
         }
-      }));
+      }, consistency));
   }
   
   /**

--- a/core/src/main/java/me/prettyprint/cassandra/model/thrift/AbstractThriftCountQuery.java
+++ b/core/src/main/java/me/prettyprint/cassandra/model/thrift/AbstractThriftCountQuery.java
@@ -6,6 +6,7 @@ import me.prettyprint.cassandra.model.KeyspaceOperationCallback;
 import me.prettyprint.cassandra.model.QueryResultImpl;
 import me.prettyprint.cassandra.service.KeyspaceService;
 import me.prettyprint.cassandra.utils.Assert;
+import me.prettyprint.hector.api.HConsistencyLevel;
 import me.prettyprint.hector.api.Keyspace;
 import me.prettyprint.hector.api.Serializer;
 import me.prettyprint.hector.api.exceptions.HectorException;
@@ -27,7 +28,8 @@ import org.apache.cassandra.thrift.ColumnParent;
   protected final Serializer<K> keySerializer;
   /** The slice predicate for which the count it performed*/
   protected final HSlicePredicate<N> slicePredicate;
-
+  protected HConsistencyLevel consistency;
+  
   public AbstractThriftCountQuery(Keyspace k, Serializer<K> keySerializer,
       Serializer<N> nameSerializer) {
     Assert.notNull(k, "keyspaceOperator can't be null");
@@ -48,6 +50,16 @@ import org.apache.cassandra.thrift.ColumnParent;
     return this;
   }
 
+  @Override
+  public HConsistencyLevel getConsistencyLevel() {
+	  return this.consistency;
+  }
+
+  @Override
+  public void setConsistencyLevel(HConsistencyLevel level) {
+	  this.consistency = level;
+  }
+  
   protected  QueryResult<Integer> countColumns() {
     Assert.notNull(key, "key is null");
     Assert.notNull(columnFamily, "columnFamily is null");
@@ -59,7 +71,7 @@ import org.apache.cassandra.thrift.ColumnParent;
             return ks.getCount(keySerializer.toByteBuffer(key), columnParent,
                 slicePredicate.toThrift());
           }
-        }), this);
+        }, consistency), this);
   }
 
   public Query<Integer> setColumnNames(N... columnNames) {

--- a/core/src/main/java/me/prettyprint/cassandra/model/thrift/ThriftColumnQuery.java
+++ b/core/src/main/java/me/prettyprint/cassandra/model/thrift/ThriftColumnQuery.java
@@ -61,6 +61,6 @@ public class ThriftColumnQuery<K, N, V> extends AbstractColumnQuery<K, N, V> imp
               return null;
             }
           }
-        }), this);
+        }, consistency), this);
   }
 }

--- a/core/src/main/java/me/prettyprint/cassandra/model/thrift/ThriftCounterColumnQuery.java
+++ b/core/src/main/java/me/prettyprint/cassandra/model/thrift/ThriftCounterColumnQuery.java
@@ -72,7 +72,7 @@ public class ThriftCounterColumnQuery<K, N> extends AbstractBasicQuery<K, N, HCo
               return null;
             }
           }
-        }), this);
+        }, consistency), this);
   }
 
 }

--- a/core/src/main/java/me/prettyprint/cassandra/model/thrift/ThriftMultigetSliceCounterQuery.java
+++ b/core/src/main/java/me/prettyprint/cassandra/model/thrift/ThriftMultigetSliceCounterQuery.java
@@ -69,7 +69,7 @@ public final class ThriftMultigetSliceCounterQuery<K, N> extends AbstractSliceQu
                 ks.multigetCounterSlice(keysList, columnParent, getPredicate()));
             return new CounterRowsImpl<K, N>(thriftRet, columnNameSerializer);
           }
-        }), this);
+        }, consistency), this);
   }
 
   @Override

--- a/core/src/main/java/me/prettyprint/cassandra/model/thrift/ThriftMultigetSliceQuery.java
+++ b/core/src/main/java/me/prettyprint/cassandra/model/thrift/ThriftMultigetSliceQuery.java
@@ -69,7 +69,7 @@ public final class ThriftMultigetSliceQuery<K, N, V> extends AbstractSliceQuery<
                 ks.multigetSlice(keysList, columnParent, getPredicate()));
             return new RowsImpl<K, N, V>(thriftRet, columnNameSerializer, valueSerializer);
           }
-        }), this);
+        }, consistency), this);
   }
 
   @Override

--- a/core/src/main/java/me/prettyprint/cassandra/model/thrift/ThriftMultigetSubSliceQuery.java
+++ b/core/src/main/java/me/prettyprint/cassandra/model/thrift/ThriftMultigetSubSliceQuery.java
@@ -80,7 +80,7 @@ public final class ThriftMultigetSubSliceQuery<K, SN, N, V> extends AbstractSlic
                 keySerializer.toBytesList(keysList), columnParent, getPredicate()));
             return new RowsImpl<K, N, V>(thriftRet, columnNameSerializer, valueSerializer);
           }
-        }), this);
+        }, consistency), this);
   }
 
   @Override

--- a/core/src/main/java/me/prettyprint/cassandra/model/thrift/ThriftMultigetSuperSliceCounterQuery.java
+++ b/core/src/main/java/me/prettyprint/cassandra/model/thrift/ThriftMultigetSuperSliceCounterQuery.java
@@ -69,7 +69,7 @@ public final class ThriftMultigetSuperSliceCounterQuery<K, SN, N> extends
             return new CounterSuperRowsImpl<K, SN, N>(thriftRet, keySerializer, columnNameSerializer,
                 nameSerializer);
           }
-        }), this);
+        }, consistency), this);
   }
 
   @Override

--- a/core/src/main/java/me/prettyprint/cassandra/model/thrift/ThriftMultigetSuperSliceQuery.java
+++ b/core/src/main/java/me/prettyprint/cassandra/model/thrift/ThriftMultigetSuperSliceQuery.java
@@ -69,7 +69,7 @@ public final class ThriftMultigetSuperSliceQuery<K, SN, N, V> extends
             return new SuperRowsImpl<K, SN, N, V>(thriftRet, keySerializer, columnNameSerializer,
                 nameSerializer, valueSerializer);
           }
-        }), this);
+        }, consistency), this);
   }
 
   @Override

--- a/core/src/main/java/me/prettyprint/cassandra/model/thrift/ThriftRangeSlicesCounterQuery.java
+++ b/core/src/main/java/me/prettyprint/cassandra/model/thrift/ThriftRangeSlicesCounterQuery.java
@@ -73,7 +73,7 @@ public final class ThriftRangeSlicesCounterQuery<K, N> extends AbstractSliceQuer
                 ks.getRangeCounterSlices(columnParent, getPredicate(), keyRange.toThrift()));
             return new OrderedCounterRowsImpl<K,N>((LinkedHashMap<K, List<CounterColumn>>) thriftRet, columnNameSerializer);
           }
-        }), this);
+        }, consistency), this);
   }
 
   @Override

--- a/core/src/main/java/me/prettyprint/cassandra/model/thrift/ThriftRangeSlicesQuery.java
+++ b/core/src/main/java/me/prettyprint/cassandra/model/thrift/ThriftRangeSlicesQuery.java
@@ -81,7 +81,7 @@ public final class ThriftRangeSlicesQuery<K, N,V> extends AbstractSliceQuery<K, 
                 ks.getRangeSlices(columnParent, getPredicate(), keyRange.toThrift()));
             return new OrderedRowsImpl<K,N,V>((LinkedHashMap<K, List<Column>>) thriftRet, columnNameSerializer, valueSerializer);
           }
-        }), this);
+        }, consistency), this);
   }
 
   @Override

--- a/core/src/main/java/me/prettyprint/cassandra/model/thrift/ThriftRangeSubSlicesCounterQuery.java
+++ b/core/src/main/java/me/prettyprint/cassandra/model/thrift/ThriftRangeSubSlicesCounterQuery.java
@@ -82,7 +82,7 @@ public final class ThriftRangeSubSlicesCounterQuery<K,SN,N> extends AbstractSlic
                 ks.getRangeCounterSlices(columnParent, getPredicate(), keyRange.toThrift()));
             return new OrderedCounterRowsImpl<K,N>((LinkedHashMap<K, List<CounterColumn>>) thriftRet, columnNameSerializer);
           }
-        }), this);
+        }, consistency), this);
   }
 
   @Override

--- a/core/src/main/java/me/prettyprint/cassandra/model/thrift/ThriftRangeSubSlicesQuery.java
+++ b/core/src/main/java/me/prettyprint/cassandra/model/thrift/ThriftRangeSubSlicesQuery.java
@@ -77,7 +77,7 @@ public final class ThriftRangeSubSlicesQuery<K,SN,N,V> extends AbstractSliceQuer
                 ks.getRangeSlices(columnParent, getPredicate(), keyRange.toThrift()));
             return new OrderedRowsImpl<K,N,V>((LinkedHashMap<K, List<Column>>) thriftRet, columnNameSerializer, valueSerializer);
           }
-        }), this);
+        }, consistency), this);
   }
 
   @Override

--- a/core/src/main/java/me/prettyprint/cassandra/model/thrift/ThriftRangeSuperSlicesCounterQuery.java
+++ b/core/src/main/java/me/prettyprint/cassandra/model/thrift/ThriftRangeSuperSlicesCounterQuery.java
@@ -73,7 +73,7 @@ public final class ThriftRangeSuperSlicesCounterQuery<K, SN, N> extends
                 (LinkedHashMap<K, List<CounterSuperColumn>>) thriftRet, keySerializer,
                 columnNameSerializer, nameSerializer);
           }
-        }), this);
+        }, consistency), this);
   }
 
   @Override

--- a/core/src/main/java/me/prettyprint/cassandra/model/thrift/ThriftRangeSuperSlicesQuery.java
+++ b/core/src/main/java/me/prettyprint/cassandra/model/thrift/ThriftRangeSuperSlicesQuery.java
@@ -74,7 +74,7 @@ public final class ThriftRangeSuperSlicesQuery<K, SN, N, V> extends
                 (LinkedHashMap<K, List<SuperColumn>>) thriftRet, keySerializer,
                 columnNameSerializer, nameSerializer, valueSerializer);
           }
-        }), this);
+        }, consistency), this);
   }
 
   @Override

--- a/core/src/main/java/me/prettyprint/cassandra/model/thrift/ThriftSliceCounterQuery.java
+++ b/core/src/main/java/me/prettyprint/cassandra/model/thrift/ThriftSliceCounterQuery.java
@@ -53,7 +53,7 @@ public final class ThriftSliceCounterQuery<K, N> extends AbstractSliceQuery<K, N
             List<CounterColumn> thriftRet = ks.getCounterSlice(keySerializer.toByteBuffer(key), columnParent, getPredicate());
             return new CounterSliceImpl<N>(thriftRet, columnNameSerializer);
           }
-        }), this);
+        }, consistency), this);
   }
 
   @Override

--- a/core/src/main/java/me/prettyprint/cassandra/model/thrift/ThriftSliceQuery.java
+++ b/core/src/main/java/me/prettyprint/cassandra/model/thrift/ThriftSliceQuery.java
@@ -53,7 +53,7 @@ public final class ThriftSliceQuery<K, N, V> extends AbstractSliceQuery<K, N, V,
             List<Column> thriftRet = ks.getSlice(keySerializer.toByteBuffer(key), columnParent, getPredicate());
             return new ColumnSliceImpl<N, V>(thriftRet, columnNameSerializer, valueSerializer);
           }
-        }), this);
+        }, consistency), this);
   }
 
   @Override

--- a/core/src/main/java/me/prettyprint/cassandra/model/thrift/ThriftSubCountQuery.java
+++ b/core/src/main/java/me/prettyprint/cassandra/model/thrift/ThriftSubCountQuery.java
@@ -55,7 +55,7 @@ public final class ThriftSubCountQuery<K,SN,N> extends AbstractThriftCountQuery<
                 slicePredicate.toThrift());
             return count;
           }
-        }), this);
+        }, consistency), this);
   }
 
   @Override

--- a/core/src/main/java/me/prettyprint/cassandra/model/thrift/ThriftSubSliceCounterQuery.java
+++ b/core/src/main/java/me/prettyprint/cassandra/model/thrift/ThriftSubSliceCounterQuery.java
@@ -65,7 +65,7 @@ public final class ThriftSubSliceCounterQuery<K,SN,N> extends AbstractSliceQuery
             List<CounterColumn> thriftRet = ks.getCounterSlice(keySerializer.toByteBuffer(key), columnParent, getPredicate());
             return new CounterSliceImpl<N>(thriftRet, columnNameSerializer);
           }
-        }), this);
+        }, consistency), this);
   }
 
   @Override

--- a/core/src/main/java/me/prettyprint/cassandra/model/thrift/ThriftSubSliceQuery.java
+++ b/core/src/main/java/me/prettyprint/cassandra/model/thrift/ThriftSubSliceQuery.java
@@ -69,7 +69,7 @@ public final class ThriftSubSliceQuery<K,SN,N,V> extends AbstractSliceQuery<K,N,
             List<Column> thriftRet = ks.getSlice(keySerializer.toByteBuffer(key), columnParent, getPredicate());
             return new ColumnSliceImpl<N, V>(thriftRet, columnNameSerializer, valueSerializer);
           }
-        }), this);
+        }, consistency), this);
   }
 
   @Override

--- a/core/src/main/java/me/prettyprint/cassandra/model/thrift/ThriftSuperColumnQuery.java
+++ b/core/src/main/java/me/prettyprint/cassandra/model/thrift/ThriftSuperColumnQuery.java
@@ -58,6 +58,6 @@ public final class ThriftSuperColumnQuery<K, SN,N,V> extends AbstractSuperColumn
               return null;
             }
           }
-        }), this);
+        }, consistency), this);
   }
 }

--- a/core/src/main/java/me/prettyprint/cassandra/model/thrift/ThriftSuperSliceCounterQuery.java
+++ b/core/src/main/java/me/prettyprint/cassandra/model/thrift/ThriftSuperSliceCounterQuery.java
@@ -61,7 +61,7 @@ public final class ThriftSuperSliceCounterQuery<K, SN, N> extends
                     columnParent, getPredicate());
             return new CounterSuperSliceImpl<SN, N>(thriftRet, columnNameSerializer, nameSerializer);
           }
-        }), this);
+        }, consistency), this);
   }
 
   @Override

--- a/core/src/main/java/me/prettyprint/cassandra/model/thrift/ThriftSuperSliceQuery.java
+++ b/core/src/main/java/me/prettyprint/cassandra/model/thrift/ThriftSuperSliceQuery.java
@@ -63,7 +63,7 @@ public final class ThriftSuperSliceQuery<K, SN, N, V> extends
             return new SuperSliceImpl<SN, N, V>(thriftRet, columnNameSerializer, nameSerializer,
                 valueSerializer);
           }
-        }), this);
+        }, consistency), this);
   }
 
   @Override

--- a/core/src/main/java/me/prettyprint/hector/api/mutation/Mutator.java
+++ b/core/src/main/java/me/prettyprint/hector/api/mutation/Mutator.java
@@ -1,5 +1,6 @@
 package me.prettyprint.hector.api.mutation;
 
+import me.prettyprint.hector.api.HConsistencyLevel;
 import me.prettyprint.hector.api.Serializer;
 import me.prettyprint.hector.api.beans.HColumn;
 import me.prettyprint.hector.api.beans.HCounterColumn;
@@ -19,6 +20,10 @@ import me.prettyprint.hector.api.beans.HSuperColumn;
  */
 public interface Mutator<K> {
 
+  public HConsistencyLevel getConsistencyLevel();
+  
+  public void setConsistencyLevel(HConsistencyLevel level);
+	  
   // Simple and immediate insertion of a column
   <N, V> MutationResult insert(final K key, final String cf, final HColumn<N, V> c);
 

--- a/core/src/main/java/me/prettyprint/hector/api/query/Query.java
+++ b/core/src/main/java/me/prettyprint/hector/api/query/Query.java
@@ -1,6 +1,7 @@
 package me.prettyprint.hector.api.query;
 
 import me.prettyprint.cassandra.model.thrift.ThriftColumnQuery;
+import me.prettyprint.hector.api.HConsistencyLevel;
 
 
 /**
@@ -29,4 +30,7 @@ public interface Query<T> {
 
   QueryResult<T> execute();
 
+  public HConsistencyLevel getConsistencyLevel();
+  
+  public void setConsistencyLevel(HConsistencyLevel level);
 }


### PR DESCRIPTION
The setConsistencyLevel method that was available in CQL queries was also implemented for thrift queries / mutator. There it acts as an override for the standard ConsistencyLevelPolicy that is set for the Keyspace.
